### PR TITLE
Absolute paths for file inclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /dbdata
 /vendor
 /node_modules
+# only ignore the root .htaccess file
+.htaccess
 
 # generated automatically by Dreamhost
 .dh-diag

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /dbdata
 /vendor
 /node_modules
-# only ignore the root .htaccess file
+# only ignore the root level .htaccess file
 .htaccess
 
 # generated automatically by Dreamhost

--- a/.htaccess.example
+++ b/.htaccess.example
@@ -1,0 +1,4 @@
+# copy this file as `.htaccess` in the project root dir and change the necessary values
+
+# set this to the FULL PATH of `config.php` in the project root dir
+php_value auto_prepend_file /var/www/config.php

--- a/config.example.php
+++ b/config.example.php
@@ -10,3 +10,6 @@ $DB_NAME = 'starcraf_coop';
 // Generating static pages
 $ADMIN_KEY = 'SuperSecretKey';
 $SERVER_NAME = 'localhost';  // use 'starcraft2coop.com' on the actual server
+
+// project root (not html root)
+const PROJECT_ROOT = __DIR__;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./html:/var/www/html
       - ./config.php:/var/www/config.php
       - ./generate.php:/var/www/generate.php
+      - ./.htaccess:/var/www/.htaccess
 
   db:
     # the values here should match config.php

--- a/generate.php
+++ b/generate.php
@@ -1,7 +1,7 @@
 <?php
 
 // run from CLI; generate static pages
-require "config.php";
+require 'config.php';
 
 $pages = [
     '/about/contact',

--- a/html/about/contact.php
+++ b/html/about/contact.php
@@ -1,18 +1,18 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Contact</title>
 </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Contact</h1>
     <p>The site is being developed in <a href="https://github.com/SerineMolecule/starcraft2coop.com">the starcraft2coop.com GitHub repository</a> right now.</p>
     <p>Aommaster is no longer involved with the site and prefers not to be contacted about it.</p>
     <p>Communities still exist at <a href="https://www.reddit.com/r/starcraft2coop/">/r/starcraft2coop on Reddit</a>, and at <a href="https://discord.gg/VQnXMdm">the StarCraft 2 Co-op Discord server</a>.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/about/contact.php
+++ b/html/about/contact.php
@@ -1,18 +1,18 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Contact</title>
 </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Contact</h1>
     <p>The site is being developed in <a href="https://github.com/SerineMolecule/starcraft2coop.com">the starcraft2coop.com GitHub repository</a> right now.</p>
     <p>Aommaster is no longer involved with the site and prefers not to be contacted about it.</p>
     <p>Communities still exist at <a href="https://www.reddit.com/r/starcraft2coop/">/r/starcraft2coop on Reddit</a>, and at <a href="https://discord.gg/VQnXMdm">the StarCraft 2 Co-op Discord server</a>.</p>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/about/faq.php
+++ b/html/about/faq.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Frequently Asked Questions</title>
   <meta name="description" content="Starcraft 2 Co-op FAQ Frequently Asked Questions">
@@ -18,7 +18,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Frequently Asked Questions</h1>
     <p>This page contains some of the more frequently asked questions regarding Co-op and the site itself.</p>
@@ -73,6 +73,6 @@ include PROJECT_ROOT . "/html/header.php";
     <h3>Wasn't there a Co-op Tournament page?</h3>
     <p>Yeah, there were two tournaments, one in 2019 and one in 2021. The <a href="/community/tournament/archive">tournament replay archives</a> still exist, and <a href="/community/tournament/index">the old signup page</a> is still accessible.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/about/faq.php
+++ b/html/about/faq.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Frequently Asked Questions</title>
   <meta name="description" content="Starcraft 2 Co-op FAQ Frequently Asked Questions">
@@ -18,7 +18,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Frequently Asked Questions</h1>
     <p>This page contains some of the more frequently asked questions regarding Co-op and the site itself.</p>
@@ -73,6 +73,6 @@ include("../header.php");
     <h3>Wasn't there a Co-op Tournament page?</h3>
     <p>Yeah, there were two tournaments, one in 2019 and one in 2021. The <a href="/community/tournament/archive">tournament replay archives</a> still exist, and <a href="/community/tournament/index">the old signup page</a> is still accessible.</p>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/about/links.php
+++ b/html/about/links.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Links</title>
   <meta name="description" content="Links to other Starcraft II Co-op community content such as speedrun replay files and records, Discord Servers and Youtube channels.">
@@ -13,7 +13,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Links - Various Other Starcraft 2 Co-op Content</h1>
     <p>Below are some links to other content (including websites) dedicated to Starcraft II Co-op.</p>
@@ -28,6 +28,6 @@ include PROJECT_ROOT . "/html/header.php";
         <li><a href="https://drive.google.com/drive/u/0/folders/0B0kAPEv3WqAeZlhmbzN5NWlDc1E" rel="nofollow">Co-op Speedrun Replays</a></li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/about/links.php
+++ b/html/about/links.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Links</title>
   <meta name="description" content="Links to other Starcraft II Co-op community content such as speedrun replay files and records, Discord Servers and Youtube channels.">
@@ -13,7 +13,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Links - Various Other Starcraft 2 Co-op Content</h1>
     <p>Below are some links to other content (including websites) dedicated to Starcraft II Co-op.</p>
@@ -28,6 +28,6 @@ include("../header.php");
         <li><a href="https://drive.google.com/drive/u/0/folders/0B0kAPEv3WqAeZlhmbzN5NWlDc1E" rel="nofollow">Co-op Speedrun Replays</a></li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/about/stats.php
+++ b/html/about/stats.php
@@ -45,8 +45,8 @@ include PROJECT_ROOT . "/html/header.php";
     <h1>Site-Specific and Co-op Related Statistics</h1>
     <?php
 
-    require_once __DIR__ . '/../data/queries.php';
-    include '../scripts/sqlconnection.php';
+    require_once PROJECT_ROOT . '/html/data/queries.php';
+    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
 
     $sql = "SELECT count(*)
             FROM mutators";

--- a/html/about/stats.php
+++ b/html/about/stats.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Statistics</title>
   <meta name="description" content="Various statistics related to starcraft2coop.com and Starcraft II content, such as mutator frequency counts in Weekly Mutations.">
@@ -40,7 +40,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Site-Specific and Co-op Related Statistics</h1>
     <?php
@@ -875,7 +875,7 @@ include("../header.php");
         });
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/about/stats.php
+++ b/html/about/stats.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Statistics</title>
   <meta name="description" content="Various statistics related to starcraft2coop.com and Starcraft II content, such as mutator frequency counts in Weekly Mutations.">
@@ -40,13 +40,13 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Site-Specific and Co-op Related Statistics</h1>
     <?php
 
     require_once PROJECT_ROOT . '/html/data/queries.php';
-    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+    include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
 
     $sql = "SELECT count(*)
             FROM mutators";
@@ -875,7 +875,7 @@ include PROJECT_ROOT . "/html/header.php";
         });
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/account.php
+++ b/html/account.php
@@ -1,15 +1,15 @@
 <?php
 
-include("header.php");
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Account</title>
 </head>
 <body>
-<?php include("menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Account</h1>
     <p>Sorry, accounts are no longer available.</p>
 </div>
-<?php include("footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/account.php
+++ b/html/account.php
@@ -1,15 +1,15 @@
 <?php
 
-include PROJECT_ROOT . "/html/header.php";
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Account</title>
 </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Account</h1>
     <p>Sorry, accounts are no longer available.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/admin-only.php
+++ b/html/admin-only.php
@@ -1,7 +1,5 @@
 <?php
 
-require __DIR__ . "/../config.php";
-
 if (!isset($_SERVER['ADMIN_KEY']) || $_SERVER['ADMIN_KEY'] != $ADMIN_KEY) {
     http_response_code(401);
     echo "Error!";

--- a/html/commanders/abathur.php
+++ b/html/commanders/abathur.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Abathur</h1>
     <p id="commanderMotto">Evolution Master</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/abathur.php
+++ b/html/commanders/abathur.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Abathur</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Abathur">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Abathur</h1>
     <p id="commanderMotto">Evolution Master</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1321,7 +1321,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Loading units into Nydus Worms will prevent them from taking DoT (damage over time) damage.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/abathur.php
+++ b/html/commanders/abathur.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Abathur</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Abathur">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Abathur</h1>
@@ -1321,7 +1321,7 @@ include("../header.php");
         <li>Loading units into Nydus Worms will prevent them from taking DoT (damage over time) damage.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/alarak.php
+++ b/html/commanders/alarak.php
@@ -65,7 +65,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Alarak</h1>
     <p id="commanderMotto">Highlord of the Tal'darim</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/alarak.php
+++ b/html/commanders/alarak.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Alarak</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Alarak">
@@ -60,7 +60,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Alarak</h1>
@@ -1301,7 +1301,7 @@ include("../header.php");
     <p>The below videos demonstrate the various fast expands explained earlier.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu5U6PR3fDDVRcpgRFZtveuG" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/alarak.php
+++ b/html/commanders/alarak.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Alarak</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Alarak">
@@ -60,12 +60,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Alarak</h1>
     <p id="commanderMotto">Highlord of the Tal'darim</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1301,7 +1301,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>The below videos demonstrate the various fast expands explained earlier.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu5U6PR3fDDVRcpgRFZtveuG" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/artanis.php
+++ b/html/commanders/artanis.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Artanis</h1>
     <p id="commanderMotto">Hierarch of the Daelaam</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/artanis.php
+++ b/html/commanders/artanis.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Artanis</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Artanis">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Artanis</h1>
@@ -1101,7 +1101,7 @@ include("../header.php");
         <li>Hold Shift when Orbital Strike is selected and press any key <a href="/guides/generaltips">bound to Rapidfire</a> to fire Orbital Strikes without delay in between shots.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/artanis.php
+++ b/html/commanders/artanis.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Artanis</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Artanis">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Artanis</h1>
     <p id="commanderMotto">Hierarch of the Daelaam</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1101,7 +1101,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Hold Shift when Orbital Strike is selected and press any key <a href="/guides/generaltips">bound to Rapidfire</a> to fire Orbital Strikes without delay in between shots.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/dehaka.php
+++ b/html/commanders/dehaka.php
@@ -39,7 +39,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Dehaka</h1>
     <p id="commanderMotto">Primal Pack Leader</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1643,7 +1643,7 @@ include PROJECT_ROOT . "/html/header.php";
     <ul>
 
     <?php
-    include '../scripts/sqlconnection.php';
+    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
     $sql = "SELECT name, race
             FROM amonunits
             WHERE psionic=1 and race<>'Objective' and race<>'Mutator'

--- a/html/commanders/dehaka.php
+++ b/html/commanders/dehaka.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Dehaka</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Dehaka">
@@ -34,12 +34,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Dehaka</h1>
     <p id="commanderMotto">Primal Pack Leader</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1643,7 +1643,7 @@ include PROJECT_ROOT . "/html/header.php";
     <ul>
 
     <?php
-    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+    include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
     $sql = "SELECT name, race
             FROM amonunits
             WHERE psionic=1 and race<>'Objective' and race<>'Mutator'
@@ -1901,7 +1901,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>If Dehaka dies, use drones to instantly respawn him. Each drone reduces Dehaka's respawn time by 24 seconds (-1 second per level for Dehaka). This can have huge negative impact on your economy in the early game, so make sure you don't lose him at the start, when he is at his weakest.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/dehaka.php
+++ b/html/commanders/dehaka.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Dehaka</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Dehaka">
@@ -34,7 +34,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Dehaka</h1>
@@ -1901,7 +1901,7 @@ include("../header.php");
         <li>If Dehaka dies, use drones to instantly respawn him. Each drone reduces Dehaka's respawn time by 24 seconds (-1 second per level for Dehaka). This can have huge negative impact on your economy in the early game, so make sure you don't lose him at the start, when he is at his weakest.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/fenix.php
+++ b/html/commanders/fenix.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Fenix</h1>
     <p id="commanderMotto">Purifier Executor</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/fenix.php
+++ b/html/commanders/fenix.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Fenix</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Fenix">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Fenix</h1>
     <p id="commanderMotto">Purifier Executor</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1456,7 +1456,7 @@ include PROJECT_ROOT . "/html/header.php";
         </li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/fenix.php
+++ b/html/commanders/fenix.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Fenix</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Fenix">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Fenix</h1>
@@ -1456,7 +1456,7 @@ include("../header.php");
         </li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/horner.php
+++ b/html/commanders/horner.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Han & Horner</h1>
     <p id="commanderMotto">Mercenary Leader and Dominion Admiral</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/horner.php
+++ b/html/commanders/horner.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Han & Horner</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Han Horner">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Han & Horner</h1>
     <p id="commanderMotto">Mercenary Leader and Dominion Admiral</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1153,7 +1153,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Space Station Reallocation does reduced damage to some non-heroic structures. For example, Zenith Stones on <a href="/missions/templeofthepast">Temple of the Past</a> do not get instantly destroyed by the calldown, despite having no Heroic tag.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/horner.php
+++ b/html/commanders/horner.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Han & Horner</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Han Horner">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Han & Horner</h1>
@@ -1153,7 +1153,7 @@ include("../header.php");
         <li>Space Station Reallocation does reduced damage to some non-heroic structures. For example, Zenith Stones on <a href="/missions/templeofthepast">Temple of the Past</a> do not get instantly destroyed by the calldown, despite having no Heroic tag.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/karax.php
+++ b/html/commanders/karax.php
@@ -65,7 +65,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Karax</h1>
     <p id="commanderMotto">Khalai Phase-Smith</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/karax.php
+++ b/html/commanders/karax.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Karax</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Karax">
@@ -60,7 +60,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Karax</h1>
@@ -1319,7 +1319,7 @@ include("../header.php");
     <p>The below videos demonstrate the various fast expands explained earlier. These fast expands are much more difficult to pull off, because you will be shooting your Solar Lances into the fog of war and will require a lot of practice.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu6-eOs3pg4Bvvn27uuvClBW" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/karax.php
+++ b/html/commanders/karax.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Karax</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Karax">
@@ -60,12 +60,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Karax</h1>
     <p id="commanderMotto">Khalai Phase-Smith</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1319,7 +1319,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>The below videos demonstrate the various fast expands explained earlier. These fast expands are much more difficult to pull off, because you will be shooting your Solar Lances into the fog of war and will require a lot of practice.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu6-eOs3pg4Bvvn27uuvClBW" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/kerrigan.php
+++ b/html/commanders/kerrigan.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Kerrigan</h1>
     <p id="commanderMotto">Queen of Blades</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/kerrigan.php
+++ b/html/commanders/kerrigan.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Kerrigan</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Kerrigan">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Kerrigan</h1>
@@ -1034,7 +1034,7 @@ include("../header.php");
         <li>Kerrigan's Psionic Shift does not need detection to damage cloaked or burrowed targets.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/kerrigan.php
+++ b/html/commanders/kerrigan.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Kerrigan</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Kerrigan">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Kerrigan</h1>
     <p id="commanderMotto">Queen of Blades</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1034,7 +1034,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Kerrigan's Psionic Shift does not need detection to damage cloaked or burrowed targets.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/mengsk.php
+++ b/html/commanders/mengsk.php
@@ -74,7 +74,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Mengsk</h1>
     <p id="commanderMotto">Emperor of the Dominion</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/mengsk.php
+++ b/html/commanders/mengsk.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Mengsk</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Mengsk">
@@ -69,7 +69,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Mengsk</h1>
@@ -1722,7 +1722,7 @@ include("../header.php");
     <p>The below videos demonstrate the various fast expands explained earlier. Note that as of patch 4.11.3, Mengsk's Starting Mandate Mastery has been modified which means the two Bunkers cannot be dropped at the start of the game. For double Bunker expands, you will need to wait (~2 mins) before both Bunkers can be placed. For single Bunker expands, the mineral line will not be saturated at the start of the game.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu67esg6PKcDnh9ejc_3UZ7p" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/mengsk.php
+++ b/html/commanders/mengsk.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Mengsk</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Mengsk">
@@ -69,12 +69,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Mengsk</h1>
     <p id="commanderMotto">Emperor of the Dominion</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1722,7 +1722,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>The below videos demonstrate the various fast expands explained earlier. Note that as of patch 4.11.3, Mengsk's Starting Mandate Mastery has been modified which means the two Bunkers cannot be dropped at the start of the game. For double Bunker expands, you will need to wait (~2 mins) before both Bunkers can be placed. For single Bunker expands, the mineral line will not be saturated at the start of the game.</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu67esg6PKcDnh9ejc_3UZ7p" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/nova.php
+++ b/html/commanders/nova.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Nova</h1>
     <p id="commanderMotto">Dominion Ghost</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/nova.php
+++ b/html/commanders/nova.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Nova</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Nova">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Nova</h1>
     <p id="commanderMotto">Dominion Ghost</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1257,7 +1257,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>If using Spider Mines for defense, place them on the top of your ramp so they can take advantage of high-ground vision range.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/nova.php
+++ b/html/commanders/nova.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Nova</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Nova">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Nova</h1>
@@ -1257,7 +1257,7 @@ include("../header.php");
         <li>If using Spider Mines for defense, place them on the top of your ramp so they can take advantage of high-ground vision range.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/raynor.php
+++ b/html/commanders/raynor.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Raynor</h1>
     <p id="commanderMotto">Renegade Commander</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/raynor.php
+++ b/html/commanders/raynor.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Raynor</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Raynor">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Raynor</h1>
@@ -1209,7 +1209,7 @@ include("../header.php");
         <li>If using Spider Mines for defense, place them on the top of your ramp so they can take advantage of high-ground vision range.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/raynor.php
+++ b/html/commanders/raynor.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Raynor</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Raynor">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Raynor</h1>
     <p id="commanderMotto">Renegade Commander</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1209,7 +1209,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>If using Spider Mines for defense, place them on the top of your ramp so they can take advantage of high-ground vision range.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/stetmann.php
+++ b/html/commanders/stetmann.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stetmann</h1>
     <p id="commanderMotto">Hero Genius (Henius)</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/stetmann.php
+++ b/html/commanders/stetmann.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Stetmann</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Stetmann">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stetmann</h1>
@@ -1305,7 +1305,7 @@ include("../header.php");
         <li>Super Gary gains a temporary attack speed buff when he picks up Mecha Remnants. Make sure Super Gary is near your army in combat to take advantage of this buff.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/stetmann.php
+++ b/html/commanders/stetmann.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Stetmann</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Stetmann">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stetmann</h1>
     <p id="commanderMotto">Hero Genius (Henius)</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1305,7 +1305,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Super Gary gains a temporary attack speed buff when he picks up Mecha Remnants. Make sure Super Gary is near your army in combat to take advantage of this buff.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/stukov.php
+++ b/html/commanders/stukov.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stukov</h1>
     <p id="commanderMotto">Infested Admiral</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/stukov.php
+++ b/html/commanders/stukov.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Stukov</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Stukov">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stukov</h1>
@@ -1124,7 +1124,7 @@ include("../header.php");
         <li>The Acidic Enzymes upgrade (available at the Factory's Tech Lab) affects Volatile Infested, which happen to be fired from the Siege Tanks. Therefore, buying this upgrade will also affect the Volatile Infested spawned from the compound.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/stukov.php
+++ b/html/commanders/stukov.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Stukov</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Stukov">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Stukov</h1>
     <p id="commanderMotto">Infested Admiral</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1124,7 +1124,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>The Acidic Enzymes upgrade (available at the Factory's Tech Lab) affects Volatile Infested, which happen to be fired from the Siege Tanks. Therefore, buying this upgrade will also affect the Volatile Infested spawned from the compound.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/swann.php
+++ b/html/commanders/swann.php
@@ -58,7 +58,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Swann</h1>
     <p id="commanderMotto">Chief Engineer</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/swann.php
+++ b/html/commanders/swann.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Swann</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Swann">
@@ -53,7 +53,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Swann</h1>
@@ -1800,7 +1800,7 @@ include("../header.php");
         <li>Use a Hercules to get vision so you can use the Drill to take out attack waves.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/swann.php
+++ b/html/commanders/swann.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Swann</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Swann">
@@ -53,12 +53,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Swann</h1>
     <p id="commanderMotto">Chief Engineer</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1800,7 +1800,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Use a Hercules to get vision so you can use the Drill to take out attack waves.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/tychus.php
+++ b/html/commanders/tychus.php
@@ -49,7 +49,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Tychus</h1>
     <p id="commanderMotto">Legendary Outlaw</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/tychus.php
+++ b/html/commanders/tychus.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Tychus</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Tychus">
@@ -44,12 +44,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Tychus</h1>
     <p id="commanderMotto">Legendary Outlaw</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1367,7 +1367,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Your choice of healer (Rattlesnake/Nikara) will depend on which outlaws you use. A build that uses lower HP outlaws (Fixers) will gain more benefit from having Nikara, whereas a higher HP outlaw set (Muscles) will benefit more from having Rattlesnake.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/tychus.php
+++ b/html/commanders/tychus.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Tychus</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Tychus">
@@ -44,7 +44,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Tychus</h1>
@@ -1367,7 +1367,7 @@ include("../header.php");
         <li>Your choice of healer (Rattlesnake/Nikara) will depend on which outlaws you use. A build that uses lower HP outlaws (Fixers) will gain more benefit from having Nikara, whereas a higher HP outlaw set (Muscles) will benefit more from having Rattlesnake.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/vorazun.php
+++ b/html/commanders/vorazun.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Vorazun</h1>
     <p id="commanderMotto">Matriarch of the Nerazim</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/vorazun.php
+++ b/html/commanders/vorazun.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Vorazun</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Vorazun">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Vorazun</h1>
@@ -1195,7 +1195,7 @@ include("../header.php");
         <li>In the early game, focus on Air attack upgrades over ground attack upgrades, as Dark Templars will be dealing most of their damage through Shadow Fury, which does not get affected by Ground attack upgrades. Additionally, Corsairs need these upgrades in order to kill enemy units.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/vorazun.php
+++ b/html/commanders/vorazun.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Vorazun</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Vorazun">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Vorazun</h1>
     <p id="commanderMotto">Matriarch of the Nerazim</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -1195,7 +1195,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>In the early game, focus on Air attack upgrades over ground attack upgrades, as Dark Templars will be dealing most of their damage through Shadow Fury, which does not get affected by Ground attack upgrades. Additionally, Corsairs need these upgrades in order to kill enemy units.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/zagara.php
+++ b/html/commanders/zagara.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zagara</h1>
     <p id="commanderMotto">Swarm Broodmother</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/zagara.php
+++ b/html/commanders/zagara.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Zagara</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Zagara">
@@ -27,12 +27,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zagara</h1>
     <p id="commanderMotto">Swarm Broodmother</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -895,7 +895,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Cast Infested Drop and Spawn Hunter Killers before you cast Mass Frenzy so the newly-spawned units also get the buff.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/commanders/zagara.php
+++ b/html/commanders/zagara.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Zagara</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Zagara">
@@ -27,7 +27,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zagara</h1>
@@ -895,7 +895,7 @@ include("../header.php");
         <li>Cast Infested Drop and Spawn Hunter Killers before you cast Mass Frenzy so the newly-spawned units also get the buff.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/zeratul.php
+++ b/html/commanders/zeratul.php
@@ -56,7 +56,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zeratul</h1>
     <p id="commanderMotto">Dark Prelate</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>

--- a/html/commanders/zeratul.php
+++ b/html/commanders/zeratul.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Zeratul</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Zeratul">
@@ -51,7 +51,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zeratul</h1>
@@ -2058,7 +2058,7 @@ include("../header.php");
     <p>The below videos demonstrate the various Legion expands explained earlier. Note that as of patch 4.11.3, Zeratul's Legion costs have been increased significantly. The expand will still take place in the same way, but at a later point in the game (~2 mins).</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu53ZsL8KSqVBysp4tPpg5CT" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/commanders/zeratul.php
+++ b/html/commanders/zeratul.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guide - Zeratul</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Guide Zeratul">
@@ -51,12 +51,12 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Co-op Commander Guide: Zeratul</h1>
     <p id="commanderMotto">Dark Prelate</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#comSum">Commander Summary</a></p>
@@ -2058,7 +2058,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>The below videos demonstrate the various Legion expands explained earlier. Note that as of patch 4.11.3, Zeratul's Legion costs have been increased significantly. The expand will still take place in the same way, but at a later point in the game (~2 mins).</p>
     <iframe width="950" height="535" src="https://www.youtube.com/embed/videoseries?list=PL-U97hco2Fu53ZsL8KSqVBysp4tPpg5CT" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/community/gamespotlight.php
+++ b/html/community/gamespotlight.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Game Spotlight</title>
   <meta name="description" content="This is the submission page to get games that feature a high skill level casted.">
@@ -26,7 +26,7 @@ include("../header.php");
     </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Game Spotlight</h1>
     <p>Game Spotlight is a special non-routine series of game casts from some of the best Co-op players in the community. The videos provide a glimpse of what Co-op looks like at the highest levels of play and show how top Co-op players handle difficult situations. Each game will be casted with added "Did You Know" facts scattered throughout the video. A full playlist is below:</p>
@@ -100,6 +100,6 @@ include("../header.php");
     </form>-->
     <p>Submissions are now closed. Thank you.</p>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/gamespotlight.php
+++ b/html/community/gamespotlight.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Game Spotlight</title>
   <meta name="description" content="This is the submission page to get games that feature a high skill level casted.">
@@ -26,7 +26,7 @@ include PROJECT_ROOT . "/html/header.php";
     </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Game Spotlight</h1>
     <p>Game Spotlight is a special non-routine series of game casts from some of the best Co-op players in the community. The videos provide a glimpse of what Co-op looks like at the highest levels of play and show how top Co-op players handle difficult situations. Each game will be casted with added "Did You Know" facts scattered throughout the video. A full playlist is below:</p>
@@ -54,7 +54,7 @@ include PROJECT_ROOT . "/html/header.php";
         if(isset($_POST['url']) && $_POST['url'] == ''){
             if(isset($_FILES["file"]) && isset($_POST['recaptcha_response'])){
 
-                include("../scripts/recaptcha.php");
+                include PROJECT_ROOT . '/html/scripts/recaptcha.php';
                 if ($recaptchaResult) {
 
                     $target_dir = "../aommaster_admin/submissions/";
@@ -100,6 +100,6 @@ include PROJECT_ROOT . "/html/header.php";
     </form>-->
     <p>Submissions are now closed. Thank you.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/mythbusters.php
+++ b/html/community/mythbusters.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Mythbusters</title>
   <meta name="description" content="This is the page which lists all the episodes of Mythbusters.">
@@ -9,7 +9,7 @@ include PROJECT_ROOT . "/html/header.php";
   <link rel="canonical" href="https://starcraft2coop.com/community/mythbusters">
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Mythbusters</h1>
     <p>Mythbusters takes theories and myths from the co-op community and puts them to the test. A full playlist is below:</p>
@@ -196,6 +196,6 @@ include PROJECT_ROOT . "/html/header.php";
     <br>Missiles from Missile Command are immune to Mind-Control
     <br>Swann can convert Tech Labs and Reactors to Tech Reactors
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/mythbusters.php
+++ b/html/community/mythbusters.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Mythbusters</title>
   <meta name="description" content="This is the page which lists all the episodes of Mythbusters.">
@@ -9,7 +9,7 @@ include("../header.php");
   <link rel="canonical" href="https://starcraft2coop.com/community/mythbusters">
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Mythbusters</h1>
     <p>Mythbusters takes theories and myths from the co-op community and puts them to the test. A full playlist is below:</p>
@@ -196,6 +196,6 @@ include("../header.php");
     <br>Missiles from Missile Command are immune to Mind-Control
     <br>Swann can convert Tech Labs and Reactors to Tech Reactors
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/rockslappingchampions.php
+++ b/html/community/rockslappingchampions.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Rockslapping Champions</title>
   <meta name="description" content="Rockslapping Champions is starcraft2coop.com's flagship series, which is very similar to Bronze League Heroes.">
@@ -63,7 +63,7 @@ include("../header.php");
     </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Rockslapping Champions</h1>
     <h2>The Series</h2>
@@ -175,6 +175,6 @@ include("../header.php");
         })
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/rockslappingchampions.php
+++ b/html/community/rockslappingchampions.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Rockslapping Champions</title>
   <meta name="description" content="Rockslapping Champions is starcraft2coop.com's flagship series, which is very similar to Bronze League Heroes.">
@@ -63,7 +63,7 @@ include PROJECT_ROOT . "/html/header.php";
     </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Rockslapping Champions</h1>
     <h2>The Series</h2>
@@ -175,6 +175,6 @@ include PROJECT_ROOT . "/html/header.php";
         })
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/tournament/archive.php
+++ b/html/community/tournament/archive.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../../admin-only.php";
-include("../../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op Tournament Archives</title>
   <meta name="description" content="Starcraft 2 Co-op Tournament Archives. Browse past Co-op Tournament summaries and watch VoD's.">
@@ -19,7 +19,7 @@ include("../../header.php");
   </style>
   </head>
 <body>
-<?php include("../../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Tournament Archives</h1>
     <p>Below are the archives of past Co-op Tournaments.
@@ -52,6 +52,6 @@ include("../../header.php");
     <a href="https://policies.google.com/privacy">Privacy Policy</a> and
     <a href="https://policies.google.com/terms">Terms of Service</a> apply.</p>
 </div>
-<?php include("../../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/tournament/archive.php
+++ b/html/community/tournament/archive.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op Tournament Archives</title>
   <meta name="description" content="Starcraft 2 Co-op Tournament Archives. Browse past Co-op Tournament summaries and watch VoD's.">
@@ -19,7 +19,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Tournament Archives</h1>
     <p>Below are the archives of past Co-op Tournaments.
@@ -52,6 +52,6 @@ include PROJECT_ROOT . "/html/header.php";
     <a href="https://policies.google.com/privacy">Privacy Policy</a> and
     <a href="https://policies.google.com/terms">Terms of Service</a> apply.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/tournament/index.php
+++ b/html/community/tournament/index.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../../admin-only.php";
-include("../../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Tournament</title>
   <meta name="description" content="Information on the one-of-a-kind Co-op Tournament, which features two teams of two battling it out in mutliple-round mutation games.">
@@ -12,7 +12,7 @@ include("../../header.php");
   </style>
   </head>
 <body>
-<?php include("../../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>The Co-Op Tournament</h1>
     <p>The Co-Op tournament is designed to test the limits of players' skill, knowledge and map awareness in Starcraft II Co-op mode. Currently, there is a $100 prize given to the winning team ($50 each player).</p>
@@ -305,6 +305,6 @@ include("../../header.php");
     ?>
 
 </div>
-<?php include("../../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/tournament/index.php
+++ b/html/community/tournament/index.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Tournament</title>
   <meta name="description" content="Information on the one-of-a-kind Co-op Tournament, which features two teams of two battling it out in mutliple-round mutation games.">
@@ -12,7 +12,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>The Co-Op Tournament</h1>
     <p>The Co-Op tournament is designed to test the limits of players' skill, knowledge and map awareness in Starcraft II Co-op mode. Currently, there is a $100 prize given to the winning team ($50 each player).</p>
@@ -298,13 +298,13 @@ include PROJECT_ROOT . "/html/header.php";
     <?php
     $closed = true;
     if ($closed) {
-        include("registrationclosed.php");
+        include 'registrationclosed.php';
     } else {
-        include("registrationopen.php");
+        include 'registrationopen.php';
     }
     ?>
 
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/tournament/summary/2019-10.php
+++ b/html/community/tournament/summary/2019-10.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Tournament Summary - Oct 2019</title>
   <meta name="description" content="Starcraft 2 Co-op Tournament Summary November 2018">
@@ -15,7 +15,7 @@ include PROJECT_ROOT . "/html/header.php";
 <body>
 <div id="header"><img src="/images/mainpageheader.png" alt="Starcraft II Co-op Logo">
 </div>
-<div id="menu"><?php include PROJECT_ROOT . "/html/menu.php"; ?></div>
+<div id="menu"><?php include PROJECT_ROOT . '/html/menu.php'; ?></div>
 <div id="content">
     <h1>Co-op Tournament Summary - October 2019</h1>
     <p>Below is the round summary for the Starcraft 2 Co-op Tournament of October 2019. Each round has been hidden by a spoiler block which can be removed by clicking the block. You may remove all spoilers and highlight the winning team by using the spoiler toggle located on the page.</p>
@@ -158,7 +158,7 @@ include PROJECT_ROOT . "/html/header.php";
             </tr>
             <?php
             $start = 3;
-            include("../fakerows.php");
+            include PROJECT_ROOT . '/html/community/tournament/fakerows.php';
             ?>
         </tbody>
 </table>
@@ -219,6 +219,6 @@ include PROJECT_ROOT . "/html/header.php";
         return false;
     });
 </script>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/tournament/summary/2019-10.php
+++ b/html/community/tournament/summary/2019-10.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../../../admin-only.php";
-include("../../../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Tournament Summary - Oct 2019</title>
   <meta name="description" content="Starcraft 2 Co-op Tournament Summary November 2018">
@@ -15,7 +15,7 @@ include("../../../header.php");
 <body>
 <div id="header"><img src="/images/mainpageheader.png" alt="Starcraft II Co-op Logo">
 </div>
-<div id="menu"><?php include("../../../menu.php"); ?></div>
+<div id="menu"><?php include PROJECT_ROOT . "/html/menu.php"; ?></div>
 <div id="content">
     <h1>Co-op Tournament Summary - October 2019</h1>
     <p>Below is the round summary for the Starcraft 2 Co-op Tournament of October 2019. Each round has been hidden by a spoiler block which can be removed by clicking the block. You may remove all spoilers and highlight the winning team by using the spoiler toggle located on the page.</p>
@@ -219,6 +219,6 @@ include("../../../header.php");
         return false;
     });
 </script>
-<?php include("../../../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/community/tournament/summary/template.php
+++ b/html/community/tournament/summary/template.php
@@ -20,7 +20,7 @@
 <body>
 <div id="header"><img src="/images/mainpageheader.png" alt="Starcraft II Co-op Logo">
 </div>
-<div id="menu"><?php include PROJECT_ROOT . "/html/menu.php"; ?></div>
+<div id="menu"><?php include PROJECT_ROOT . '/html/menu.php'; ?></div>
 <div id="content">
     <h1>Co-op Tournament Summary - November 2018</h1>
     <!-- Paste the content before the tooltip tag here -->
@@ -96,6 +96,6 @@
         return false;
     });
 </script>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/community/tournament/summary/template.php
+++ b/html/community/tournament/summary/template.php
@@ -20,7 +20,7 @@
 <body>
 <div id="header"><img src="/images/mainpageheader.png" alt="Starcraft II Co-op Logo">
 </div>
-<div id="menu"><?php include("../../../menu.php"); ?></div>
+<div id="menu"><?php include PROJECT_ROOT . "/html/menu.php"; ?></div>
 <div id="content">
     <h1>Co-op Tournament Summary - November 2018</h1>
     <!-- Paste the content before the tooltip tag here -->
@@ -96,6 +96,6 @@
         return false;
     });
 </script>
-<?php include("../../../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/ctg/index.php
+++ b/html/ctg/index.php
@@ -98,7 +98,7 @@
   </head>
 <body>
     <?php
-    include '../scripts/sqlconnection.php';
+    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
     $sql = "SELECT mutatorid, mutatorname, mutatordescription, abomination
                 FROM mutators
                 ORDER BY mutatorid ASC";

--- a/html/ctg/index.php
+++ b/html/ctg/index.php
@@ -98,7 +98,7 @@
   </head>
 <body>
     <?php
-    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+    include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
     $sql = "SELECT mutatorid, mutatorname, mutatordescription, abomination
                 FROM mutators
                 ORDER BY mutatorid ASC";

--- a/html/errors/404.php
+++ b/html/errors/404.php
@@ -26,7 +26,7 @@
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <?php
     if (isset($_SERVER['HTTP_REFERER'])) {
@@ -59,6 +59,6 @@
     <p>(Either that, or the page was not found.)</p>
 
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/errors/404.php
+++ b/html/errors/404.php
@@ -26,7 +26,7 @@
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <?php
     if (isset($_SERVER['HTTP_REFERER'])) {
@@ -59,6 +59,6 @@
     <p>(Either that, or the page was not found.)</p>
 
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/guides/buildordertheory.php
+++ b/html/guides/buildordertheory.php
@@ -37,7 +37,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Build Order Theory: How to Develop Your Own Build Orders</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#what">What is a Build Order</a></p>

--- a/html/guides/buildordertheory.php
+++ b/html/guides/buildordertheory.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Build Order Theory</title>
   <meta name="description" content="Learn how to make your own Co-op build orders and adapt your build to face challenges like mutators and weekly mutations.">
@@ -34,10 +34,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Build Order Theory: How to Develop Your Own Build Orders</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#what">What is a Build Order</a></p>
@@ -844,7 +844,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>At the end of the day, taking an expansion and saturating it as fast as possible will yield the best possible results. How to do that, given a set of circumstances, whether it is a mission or a mutator, is up to the player.</p>
     <p>Build orders are mostly tried and tested several times before an optimal build order is achieved. Players are advised to constantly question and attempt to fine-tune their build orders if they wish to arrive at a perfectly optimal build.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/guides/buildordertheory.php
+++ b/html/guides/buildordertheory.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Build Order Theory</title>
   <meta name="description" content="Learn how to make your own Co-op build orders and adapt your build to face challenges like mutators and weekly mutations.">
@@ -34,7 +34,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Build Order Theory: How to Develop Your Own Build Orders</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -844,7 +844,7 @@ include("../header.php");
     <p>At the end of the day, taking an expansion and saturating it as fast as possible will yield the best possible results. How to do that, given a set of circumstances, whether it is a mission or a mutator, is up to the player.</p>
     <p>Build orders are mostly tried and tested several times before an optimal build order is achieved. Players are advised to constantly question and attempt to fine-tune their build orders if they wish to arrive at a perfectly optimal build.</p>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/guides/enemycomps.php
+++ b/html/guides/enemycomps.php
@@ -88,7 +88,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Enemy Compositions: Units in Attack Waves and Hybrid Data</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#genNotes">General Notes</a></p>

--- a/html/guides/enemycomps.php
+++ b/html/guides/enemycomps.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Enemy Compositions</title>
   <meta name="description" content="Starcraft 2 Co-op Enemy Compositions. Learn about Hybrids and the different units in Amon's attack waves.">
@@ -85,10 +85,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Enemy Compositions: Units in Attack Waves and Hybrid Data</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#genNotes">General Notes</a></p>
@@ -1118,7 +1118,7 @@ include PROJECT_ROOT . "/html/header.php";
         </div>
     </div>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/guides/enemycomps.php
+++ b/html/guides/enemycomps.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Enemy Compositions</title>
   <meta name="description" content="Starcraft 2 Co-op Enemy Compositions. Learn about Hybrids and the different units in Amon's attack waves.">
@@ -85,7 +85,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Enemy Compositions: Units in Attack Waves and Hybrid Data</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -1118,7 +1118,7 @@ include("../header.php");
         </div>
     </div>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/guides/generaltips.php
+++ b/html/guides/generaltips.php
@@ -23,7 +23,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>General Tips For Co-op Players</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#tips1">Tips for Beginners</a></p>

--- a/html/guides/generaltips.php
+++ b/html/guides/generaltips.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - General Tips for Co-op Players</title>
   <meta name="description" content="Improve your Co-op gameplay with these simple tips, made for players of all skill levels. Beginners and Veterans can all benefit.">
@@ -20,7 +20,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>General Tips For Co-op Players</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -123,7 +123,7 @@ include("../header.php");
     <p>In Versus games, the worker count displayed at the top of the Primary Structure denotes the worker count that corresponds to the Optimal mining rate. However, in Co-op, the value denotes the Maximum mining rate. More information on these mining rates can be found in the <a href="/guides/buildordertheory">Build Order Theory</a> Guide.</p>
     <img src="/images/newplayer/workercounts.jpg" alt="Worker Counts">
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/guides/generaltips.php
+++ b/html/guides/generaltips.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - General Tips for Co-op Players</title>
   <meta name="description" content="Improve your Co-op gameplay with these simple tips, made for players of all skill levels. Beginners and Veterans can all benefit.">
@@ -20,10 +20,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>General Tips For Co-op Players</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#tips1">Tips for Beginners</a></p>
@@ -123,7 +123,7 @@ include PROJECT_ROOT . "/html/header.php";
     <p>In Versus games, the worker count displayed at the top of the Primary Structure denotes the worker count that corresponds to the Optimal mining rate. However, in Co-op, the value denotes the Maximum mining rate. More information on these mining rates can be found in the <a href="/guides/buildordertheory">Build Order Theory</a> Guide.</p>
     <img src="/images/newplayer/workercounts.jpg" alt="Worker Counts">
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/guides/newplayer.php
+++ b/html/guides/newplayer.php
@@ -164,7 +164,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="commanderSelection">
         <?php
 
-        require_once __DIR__ . '/../data/queries.php';
+        require_once PROJECT_ROOT . '/html/data/queries.php';
 
         $allCommanders = get_commanders();
         foreach ($allCommanders as $row) {

--- a/html/guides/newplayer.php
+++ b/html/guides/newplayer.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Selection Guide</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Selection Guide for new players, providing information on strengths and weaknesses of commanders.">
@@ -91,7 +91,7 @@ include("../header.php");
 
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>New Player Commander Selection</h1>
@@ -219,6 +219,6 @@ include("../header.php");
         }
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/guides/newplayer.php
+++ b/html/guides/newplayer.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Selection Guide</title>
   <meta name="description" content="Starcraft 2 Co-op Commander Selection Guide for new players, providing information on strengths and weaknesses of commanders.">
@@ -91,7 +91,7 @@ include PROJECT_ROOT . "/html/header.php";
 
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>New Player Commander Selection</h1>
@@ -219,6 +219,6 @@ include PROJECT_ROOT . "/html/header.php";
         }
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/guides/youtube.php
+++ b/html/guides/youtube.php
@@ -1,12 +1,12 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - YouTube</title>
 </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>YouTube</h1>
     <p>We have several guides on YouTube:</p>
@@ -17,6 +17,6 @@ include("../header.php");
             <li><a href="https://www.youtube.com/c/starcraft2coop">Entire Starcraft2coop.com YouTube Channel</a></li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/guides/youtube.php
+++ b/html/guides/youtube.php
@@ -1,12 +1,12 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - YouTube</title>
 </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>YouTube</h1>
     <p>We have several guides on YouTube:</p>
@@ -17,6 +17,6 @@ include PROJECT_ROOT . "/html/header.php";
             <li><a href="https://www.youtube.com/c/starcraft2coop">Entire Starcraft2coop.com YouTube Channel</a></li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/index.php
+++ b/html/index.php
@@ -1,5 +1,5 @@
 <?php
-include PROJECT_ROOT . "/html/header.php";
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Commander Guides, Mission Data and more!</title>
   <meta name="description" content="Your #1 Source for Starcraft 2 Co-op Information. Commander Guides, Mission Data, Unit Stats, Mutation Information and more!">
@@ -33,7 +33,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Starcraft II Co-op</h1>
     <p>Starcraft II is a real-time strategy game by Blizzard Entertainment. It is one of the most successful RTS's in history. In 2015, Starcraft II introduced a co-op mode, where two players would face up against Amon in a PVE-type mission. The game features several different commanders to play and many different maps to choose from.</p>
@@ -59,6 +59,6 @@ include PROJECT_ROOT . "/html/header.php";
         </tr>
     </table>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/index.php
+++ b/html/index.php
@@ -1,5 +1,5 @@
 <?php
-include("header.php");
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Commander Guides, Mission Data and more!</title>
   <meta name="description" content="Your #1 Source for Starcraft 2 Co-op Information. Commander Guides, Mission Data, Unit Stats, Mutation Information and more!">
@@ -33,7 +33,7 @@ include("header.php");
   </style>
   </head>
 <body>
-<?php include("menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Starcraft II Co-op</h1>
     <p>Starcraft II is a real-time strategy game by Blizzard Entertainment. It is one of the most successful RTS's in history. In 2015, Starcraft II introduced a co-op mode, where two players would face up against Amon in a PVE-type mission. The game features several different commanders to play and many different maps to choose from.</p>
@@ -59,6 +59,6 @@ include("header.php");
         </tr>
     </table>
 </div>
-<?php include("footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/missions/chainofascension.php
+++ b/html/missions/chainofascension.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Chain of Ascension</h1>
     <p id="missionPlace">Slayn</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/chainofascension.php
+++ b/html/missions/chainofascension.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Chain of Ascension</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Chain of Ascension">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Chain of Ascension</h1>
     <p id="missionPlace">Slayn</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -503,7 +503,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zagara">Zagara</a>: Build your macro hatcheries at your expansion for quick reinforcements.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/chainofascension.php
+++ b/html/missions/chainofascension.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Chain of Ascension</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Chain of Ascension</h1>
     <p id="missionPlace">Slayn</p>
@@ -503,7 +503,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zagara">Zagara</a>: Build your macro hatcheries at your expansion for quick reinforcements.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/cradleofdeath.php
+++ b/html/missions/cradleofdeath.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Cradle of Death</h1>
     <p id="missionPlace">Moebius Battle Station</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/cradleofdeath.php
+++ b/html/missions/cradleofdeath.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Cradle of Death</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Cradle of Death</h1>
     <p id="missionPlace">Moebius Battle Station</p>
@@ -365,7 +365,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place plenty of Void Arrays around the map to be able to deal with the attack waves as well as push effectively.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/cradleofdeath.php
+++ b/html/missions/cradleofdeath.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Cradle of Death</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Cradle of Death">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Cradle of Death</h1>
     <p id="missionPlace">Moebius Battle Station</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -365,7 +365,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place plenty of Void Arrays around the map to be able to deal with the attack waves as well as push effectively.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/deadofnight.php
+++ b/html/missions/deadofnight.php
@@ -22,7 +22,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Dead of Night</h1>
     <p id="missionPlace">Chazington</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/deadofnight.php
+++ b/html/missions/deadofnight.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Dead of Night</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Dead of Night">
@@ -18,11 +18,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Dead of Night</h1>
     <p id="missionPlace">Chazington</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -500,7 +500,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Zeratul's Purity of Will passive allows him to escape from a Choker stun when the immunity buff is applied to him.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/deadofnight.php
+++ b/html/missions/deadofnight.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Dead of Night</title>
@@ -18,7 +18,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Dead of Night</h1>
     <p id="missionPlace">Chazington</p>
@@ -500,7 +500,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Zeratul's Purity of Will passive allows him to escape from a Choker stun when the immunity buff is applied to him.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/lockload.php
+++ b/html/missions/lockload.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Lock & Load</h1>
     <p id="missionPlace">Ulnar</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/lockload.php
+++ b/html/missions/lockload.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Lock & Load</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Lock & Load</h1>
     <p id="missionPlace">Ulnar</p>
@@ -255,7 +255,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place a Void Array on each captured Lock to give you the mobility to defend against attack waves.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/lockload.php
+++ b/html/missions/lockload.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Lock & Load</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Lock & Load">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Lock & Load</h1>
     <p id="missionPlace">Ulnar</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -255,7 +255,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place a Void Array on each captured Lock to give you the mobility to defend against attack waves.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/malwarfare.php
+++ b/html/missions/malwarfare.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Malwarfare</h1>
     <p id="missionPlace">Purifer Facility</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/malwarfare.php
+++ b/html/missions/malwarfare.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Malwarfare</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Malwarfare">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Malwarfare</h1>
     <p id="missionPlace">Purifer Facility</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -438,7 +438,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Use Void Arrays outside each of the Suppression Tower spawn locations to allow you to access them quickly.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/malwarfare.php
+++ b/html/missions/malwarfare.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Malwarfare</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Malwarfare</h1>
     <p id="missionPlace">Purifer Facility</p>
@@ -438,7 +438,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Use Void Arrays outside each of the Suppression Tower spawn locations to allow you to access them quickly.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/minerevacuation.php
+++ b/html/missions/minerevacuation.php
@@ -16,7 +16,7 @@ include PROJECT_ROOT . "/html/header.php";
 <div id="content">
     <h1>Co-op Mission Guide: Miner Evacuation</h1>
     <p id="missionPlace">Jarban</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/minerevacuation.php
+++ b/html/missions/minerevacuation.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Miner Evacuation</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Miner Evacuation">
@@ -12,11 +12,11 @@ include PROJECT_ROOT . "/html/header.php";
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Miner Evacuation</h1>
     <p id="missionPlace">Jarban</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -300,7 +300,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li><a href="/commanders/zeratul">Zeratul</a>: Use Void Arrays to quickly reinforce your army.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/minerevacuation.php
+++ b/html/missions/minerevacuation.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Miner Evacuation</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Miner Evacuation">
@@ -12,7 +12,7 @@ include("../header.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Miner Evacuation</h1>
     <p id="missionPlace">Jarban</p>
@@ -300,7 +300,7 @@ include("../header.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Use Void Arrays to quickly reinforce your army.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/mistopportunities.php
+++ b/html/missions/mistopportunities.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Mist Opportunities</h1>
     <p id="missionPlace">Belshir</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/mistopportunities.php
+++ b/html/missions/mistopportunities.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Mist Opportunities</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Mist Opportunities</h1>
     <p id="missionPlace">Belshir</p>
@@ -456,7 +456,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Void Arrays can give you great mobility to defend multiple bots in quick succession.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/mistopportunities.php
+++ b/html/missions/mistopportunities.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Mist Opportunities</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Mist Opportunities">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Mist Opportunities</h1>
     <p id="missionPlace">Belshir</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -456,7 +456,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Void Arrays can give you great mobility to defend multiple bots in quick succession.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/oblivionexpress.php
+++ b/html/missions/oblivionexpress.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Oblivion Express</h1>
     <p id="missionPlace">Tarsonis</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/oblivionexpress.php
+++ b/html/missions/oblivionexpress.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Oblivion Express</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Oblivion Express">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Oblivion Express</h1>
     <p id="missionPlace">Tarsonis</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -258,7 +258,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/tychus">Tychus</a>: Crooked Sam can place a demolition charge on each train carriage, making him a fantastic source of DPS.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/oblivionexpress.php
+++ b/html/missions/oblivionexpress.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Oblivion Express</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Oblivion Express</h1>
     <p id="missionPlace">Tarsonis</p>
@@ -258,7 +258,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/tychus">Tychus</a>: Crooked Sam can place a demolition charge on each train carriage, making him a fantastic source of DPS.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/partparcel.php
+++ b/html/missions/partparcel.php
@@ -22,7 +22,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Part and Parcel</h1>
     <p id="missionPlace">Moebius Research Station</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/partparcel.php
+++ b/html/missions/partparcel.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Part and Parcel</title>
@@ -18,7 +18,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Part and Parcel</h1>
     <p id="missionPlace">Moebius Research Station</p>
@@ -296,7 +296,7 @@ require_once("../scripts/switchergenerator.php");
     </ul>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/YkCX8PXqyAc" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/partparcel.php
+++ b/html/missions/partparcel.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Part and Parcel</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Part and Parcel">
@@ -18,11 +18,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Part and Parcel</h1>
     <p id="missionPlace">Moebius Research Station</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -296,7 +296,7 @@ require_once("../scripts/switchergenerator.php");
     </ul>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/YkCX8PXqyAc" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/riftstokorhal.php
+++ b/html/missions/riftstokorhal.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Rifts to Korhal</h1>
     <p id="missionPlace">Korhal</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/riftstokorhal.php
+++ b/html/missions/riftstokorhal.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Rifts to Korhal</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Rifts to Korhal">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Rifts to Korhal</h1>
     <p id="missionPlace">Korhal</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -244,7 +244,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/swann">Swann</a>: Concentrated Beam can be used to deal with all the attack waves, and can even wipe it out entirely if placed correctly.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/riftstokorhal.php
+++ b/html/missions/riftstokorhal.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Rifts to Korhal</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Rifts to Korhal</h1>
     <p id="missionPlace">Korhal</p>
@@ -244,7 +244,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/swann">Swann</a>: Concentrated Beam can be used to deal with all the attack waves, and can even wipe it out entirely if placed correctly.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/scytheofamon.php
+++ b/html/missions/scytheofamon.php
@@ -34,7 +34,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Scythe of Amon</h1>
     <p id="missionPlace">Xel'Naga Temple</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/scytheofamon.php
+++ b/html/missions/scytheofamon.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Scythe of Amon</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Scythe of Amon">
@@ -30,11 +30,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Scythe of Amon</h1>
     <p id="missionPlace">Xel'Naga Temple</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -507,7 +507,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: The Void Suppression Crystal can be used to interrupt and disable all Void Sliver abilities.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/scytheofamon.php
+++ b/html/missions/scytheofamon.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Scythe of Amon</title>
@@ -30,7 +30,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Scythe of Amon</h1>
     <p id="missionPlace">Xel'Naga Temple</p>
@@ -507,7 +507,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: The Void Suppression Crystal can be used to interrupt and disable all Void Sliver abilities.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/templeofthepast.php
+++ b/html/missions/templeofthepast.php
@@ -27,7 +27,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Temple of the Past</h1>
     <p id="missionPlace">Shakuras</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/templeofthepast.php
+++ b/html/missions/templeofthepast.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Temple of the Past</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Temple of the Past">
@@ -23,11 +23,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Temple of the Past</h1>
     <p id="missionPlace">Shakuras</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -633,7 +633,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/raynor">Raynor</a>: If you use Vultures, place Spider-mines on attack wave and Thrasher spawn locations to weaken them.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/templeofthepast.php
+++ b/html/missions/templeofthepast.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Temple of the Past</title>
@@ -23,7 +23,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Temple of the Past</h1>
     <p id="missionPlace">Shakuras</p>
@@ -633,7 +633,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/raynor">Raynor</a>: If you use Vultures, place Spider-mines on attack wave and Thrasher spawn locations to weaken them.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/thevermillionproblem.php
+++ b/html/missions/thevermillionproblem.php
@@ -34,7 +34,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: The Vermillion Problem</h1>
     <p id="missionPlace">Veridia Prime</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/thevermillionproblem.php
+++ b/html/missions/thevermillionproblem.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - The Vermillion Problem</title>
@@ -30,7 +30,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: The Vermillion Problem</h1>
     <p id="missionPlace">Veridia Prime</p>
@@ -261,7 +261,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place a Void Array on each of the islands to help you intercept attack waves and crystals in a timely manner.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/thevermillionproblem.php
+++ b/html/missions/thevermillionproblem.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - The Vermillion Problem</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide The Vermillion Problem">
@@ -30,11 +30,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: The Vermillion Problem</h1>
     <p id="missionPlace">Veridia Prime</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -261,7 +261,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/zeratul">Zeratul</a>: Place a Void Array on each of the islands to help you intercept attack waves and crystals in a timely manner.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/voidlaunch.php
+++ b/html/missions/voidlaunch.php
@@ -17,7 +17,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Void Launch</h1>
     <p id="missionPlace">Kaldir</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/voidlaunch.php
+++ b/html/missions/voidlaunch.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Void Launch</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Void Launch">
@@ -13,11 +13,11 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Void Launch</h1>
     <p id="missionPlace">Kaldir</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -413,7 +413,7 @@ require_once("../scripts/switchergenerator.php");
     </ul>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/YXDuDOIrkro" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/missions/voidlaunch.php
+++ b/html/missions/voidlaunch.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Void Launch</title>
@@ -13,7 +13,7 @@ require_once("../scripts/switchergenerator.php");
   <script src="/scripts/preload.js"></script>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Void Launch</h1>
     <p id="missionPlace">Kaldir</p>
@@ -413,7 +413,7 @@ require_once("../scripts/switchergenerator.php");
     </ul>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/YXDuDOIrkro" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/voidthrashing.php
+++ b/html/missions/voidthrashing.php
@@ -22,7 +22,7 @@ require_once("../scripts/switchergenerator.php");
 <div id="content">
     <h1>Co-op Mission Guide: Void Thrashing</h1>
     <p id="missionPlace">Char</p>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>

--- a/html/missions/voidthrashing.php
+++ b/html/missions/voidthrashing.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 require_once("../scripts/switchergenerator.php");
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Void Thrashing</title>
@@ -18,7 +18,7 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Void Thrashing</h1>
     <p id="missionPlace">Char</p>
@@ -271,7 +271,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/stukov">Stukov</a>: Move your Infested Colonist Compound to the first Void Thrasher location after it is killed for quick reinforcements.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/missions/voidthrashing.php
+++ b/html/missions/voidthrashing.php
@@ -1,8 +1,8 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
-require_once("../scripts/switchergenerator.php");
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
+require_once PROJECT_ROOT . '/html/scripts/switchergenerator.php';
 ?>
   <title>Starcraft 2 Co-op - Mission Guide - Void Thrashing</title>
   <meta name="description" content="Starcraft 2 Co-op Mission Guide Void Thrasing">
@@ -18,11 +18,11 @@ require_once("../scripts/switchergenerator.php");
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mission Guide: Void Thrashing</h1>
     <p id="missionPlace">Char</p>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#misSum">Mission Summary</a></p>
@@ -271,7 +271,7 @@ require_once("../scripts/switchergenerator.php");
         <li><a href="/commanders/stukov">Stukov</a>: Move your Infested Colonist Compound to the first Void Thrasher location after it is killed for quick reinforcements.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/achievements.php
+++ b/html/resources/achievements.php
@@ -23,7 +23,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Achievements: Unlockable Achievements for Players</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <p>There are several unlockable Co-op Mode achievements available for players to earn. These can be divided into two categories, shown below. Note that the achievements listed on this page is not an exhaustive list.</p>
     <ul>
         <li><b>Commander-specific Achievements:</b> These are specific to various gameplay elements of Co-op Commanders. Please check the individual commander pages for a list of their specific achievements.</li>

--- a/html/resources/achievements.php
+++ b/html/resources/achievements.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Achievements</title>
   <meta name="description" content="A list of achievements in Starcraft II's Co-op game mode, with descriptions and images, along with unlock criteria.">
@@ -20,10 +20,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
 </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Achievements: Unlockable Achievements for Players</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <p>There are several unlockable Co-op Mode achievements available for players to earn. These can be divided into two categories, shown below. Note that the achievements listed on this page is not an exhaustive list.</p>
     <ul>
         <li><b>Commander-specific Achievements:</b> These are specific to various gameplay elements of Co-op Commanders. Please check the individual commander pages for a list of their specific achievements.</li>
@@ -496,6 +496,6 @@ include PROJECT_ROOT . "/html/header.php";
         </table>
     </div>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/resources/achievements.php
+++ b/html/resources/achievements.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Achievements</title>
   <meta name="description" content="A list of achievements in Starcraft II's Co-op game mode, with descriptions and images, along with unlock criteria.">
@@ -20,7 +20,7 @@ include("../header.php");
   </style>
 </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Achievements: Unlockable Achievements for Players</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -496,6 +496,6 @@ include("../header.php");
         </table>
     </div>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/resources/ailogic.php
+++ b/html/resources/ailogic.php
@@ -32,7 +32,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>AI Logic: Ability Usage Conditions</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#genNotes">General Notes</a></p>

--- a/html/resources/ailogic.php
+++ b/html/resources/ailogic.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - AI Logic</title>
   <meta name="description" content="Starcraft 2 Co-op AI logic. Learn about how the different abilities are used by spellcasters and when they use them.">
@@ -29,10 +29,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>AI Logic: Ability Usage Conditions</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#genNotes">General Notes</a></p>
@@ -1736,7 +1736,7 @@ include PROJECT_ROOT . "/html/header.php";
         </div>
     </div>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/ailogic.php
+++ b/html/resources/ailogic.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - AI Logic</title>
   <meta name="description" content="Starcraft 2 Co-op AI logic. Learn about how the different abilities are used by spellcasters and when they use them.">
@@ -29,7 +29,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>AI Logic: Ability Usage Conditions</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -1736,7 +1736,7 @@ include("../header.php");
         </div>
     </div>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/brutal.php
+++ b/html/resources/brutal.php
@@ -62,7 +62,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Brutal+ Difficulty: Mutation Cost Brackets and Templates</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <p>Brutal+ is considered an "Extended Difficulty". That is, missions will take place on the regular Brutal difficulty. However, in addition to the standard mission mechanics, a certain number of random <a href="mutators">mutators</a> are added to your game. You may queue into random queue on Brutal+ difficulty, as long as the commander you are queueing in with is at Level 15. For Brutal+2 and higher, you will require a person in your party to play.</p>
     <p>To learn more about how Brutal+ difficulty mutators are selected, you may watch the video below. The video goes over what Mutation Templates are, how the different mutator possibility counts are calculated mathematically and then how the weightings are rebalanced to be more in line with Blizzard's design intent.</p>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/9jfWuM215_c" allow="autoplay; encrypted-media" allowfullscreen></iframe>
@@ -79,7 +79,7 @@ include PROJECT_ROOT . "/html/header.php";
         </thead>
         <tbody>
             <?php
-            include '../scripts/sqlconnection.php';
+            include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
 
             $sql = "SELECT *
                     FROM brutalplus

--- a/html/resources/brutal.php
+++ b/html/resources/brutal.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Brutal+ Difficulty</title>
   <meta name="description" content="Starcraft 2 Co-op Brutal+ Difficulty Mutators">
@@ -59,10 +59,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Brutal+ Difficulty: Mutation Cost Brackets and Templates</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <p>Brutal+ is considered an "Extended Difficulty". That is, missions will take place on the regular Brutal difficulty. However, in addition to the standard mission mechanics, a certain number of random <a href="mutators">mutators</a> are added to your game. You may queue into random queue on Brutal+ difficulty, as long as the commander you are queueing in with is at Level 15. For Brutal+2 and higher, you will require a person in your party to play.</p>
     <p>To learn more about how Brutal+ difficulty mutators are selected, you may watch the video below. The video goes over what Mutation Templates are, how the different mutator possibility counts are calculated mathematically and then how the weightings are rebalanced to be more in line with Blizzard's design intent.</p>
     <iframe width="475" height="268" src="https://www.youtube.com/embed/9jfWuM215_c" allow="autoplay; encrypted-media" allowfullscreen></iframe>
@@ -79,7 +79,7 @@ include PROJECT_ROOT . "/html/header.php";
         </thead>
         <tbody>
             <?php
-            include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+            include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
 
             $sql = "SELECT *
                     FROM brutalplus
@@ -319,6 +319,6 @@ include PROJECT_ROOT . "/html/header.php";
 
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/resources/brutal.php
+++ b/html/resources/brutal.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Brutal+ Difficulty</title>
   <meta name="description" content="Starcraft 2 Co-op Brutal+ Difficulty Mutators">
@@ -59,7 +59,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Brutal+ Difficulty: Mutation Cost Brackets and Templates</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -319,6 +319,6 @@ include("../header.php");
 
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/resources/bugs.php
+++ b/html/resources/bugs.php
@@ -12,7 +12,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Starcraft Co-op Bugs List</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#core">Game Core</a></p>

--- a/html/resources/bugs.php
+++ b/html/resources/bugs.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Bugs List</title>
   <meta name="description" content="A list of bugs that are present in the current Starcraft II Co-op Patch">
@@ -9,10 +9,10 @@ include PROJECT_ROOT . "/html/header.php";
   <link rel="canonical" href="https://starcraft2coop.com/resources/bugs">
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Starcraft Co-op Bugs List</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#core">Game Core</a></p>
@@ -528,7 +528,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>When a player unit kills a missile from Missile Command with Just Die! active, the Just Die! respawn animation occurs on the player unit instead of the missile</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/bugs.php
+++ b/html/resources/bugs.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Bugs List</title>
   <meta name="description" content="A list of bugs that are present in the current Starcraft II Co-op Patch">
@@ -9,7 +9,7 @@ include("../header.php");
   <link rel="canonical" href="https://starcraft2coop.com/resources/bugs">
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Starcraft Co-op Bugs List</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -528,7 +528,7 @@ include("../header.php");
         <li>When a player unit kills a missile from Missile Command with Just Die! active, the Just Die! respawn animation occurs on the player unit instead of the missile</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/deathprevention.php
+++ b/html/resources/deathprevention.php
@@ -17,8 +17,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Order of Death Prevention Effects</h1>
-    <?php
-    include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <h2>Summary</h2>
     <p>Death Prevention Effects are effects that stop a unit from dying. Examples of these are <a href="/commanders/artanis">Artanis' Guardian Shell</a> and <a href="/commanders/kerrigan">Kerrigan's Torrasque Strain Ultralisk Passive</a>. When multiple Death Prevention Effects are active, it is difficult to predict what order they will trigger. The order of Death Prevention Effects is shown in the following section.</p>
     <p>For a little more context, this page was created to act as a supplement to the following video:</p>

--- a/html/resources/deathprevention.php
+++ b/html/resources/deathprevention.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Order of Death Prevention Effects</title>
   <meta name="description" content="Order of Death Prevention Effect Triggers in Starcraft 2 Co-op">
@@ -14,10 +14,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Order of Death Prevention Effects</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <h2>Summary</h2>
     <p>Death Prevention Effects are effects that stop a unit from dying. Examples of these are <a href="/commanders/artanis">Artanis' Guardian Shell</a> and <a href="/commanders/kerrigan">Kerrigan's Torrasque Strain Ultralisk Passive</a>. When multiple Death Prevention Effects are active, it is difficult to predict what order they will trigger. The order of Death Prevention Effects is shown in the following section.</p>
     <p>For a little more context, this page was created to act as a supplement to the following video:</p>
@@ -100,6 +100,6 @@ include PROJECT_ROOT . "/html/header.php";
         </tbody>
     </table>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/resources/deathprevention.php
+++ b/html/resources/deathprevention.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Order of Death Prevention Effects</title>
   <meta name="description" content="Order of Death Prevention Effect Triggers in Starcraft 2 Co-op">
@@ -14,7 +14,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Order of Death Prevention Effects</h1>
     <?php
@@ -101,6 +101,6 @@ include("../header.php");
         </tbody>
     </table>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/resources/eastereggs.php
+++ b/html/resources/eastereggs.php
@@ -19,7 +19,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Easter Eggs and Other Hidden Content in Co-op</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <p>A number of Easter Eggs are hidden throughout the Co-op mode content. These are listed below.</p>
     <h2>Commander-Specific</h2>
     <h3>Alarak's Crystal</h3>

--- a/html/resources/eastereggs.php
+++ b/html/resources/eastereggs.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Easter Eggs</title>
   <meta name="description" content="Easter Eggs are a staple in most video games and Co-op is no different. This page lists out all the Easter Eggs found in Co-op.">
@@ -16,7 +16,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Easter Eggs and Other Hidden Content in Co-op</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -70,6 +70,6 @@ include("../header.php");
         <li>"Have you ever wondered what happened to Reigel?"<br>"Not really. It always seemed like he knew more than he let on, though".</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/resources/eastereggs.php
+++ b/html/resources/eastereggs.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Easter Eggs</title>
   <meta name="description" content="Easter Eggs are a staple in most video games and Co-op is no different. This page lists out all the Easter Eggs found in Co-op.">
@@ -16,10 +16,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Easter Eggs and Other Hidden Content in Co-op</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <p>A number of Easter Eggs are hidden throughout the Co-op mode content. These are listed below.</p>
     <h2>Commander-Specific</h2>
     <h3>Alarak's Crystal</h3>
@@ -70,6 +70,6 @@ include PROJECT_ROOT . "/html/header.php";
         <li>"Have you ever wondered what happened to Reigel?"<br>"Not really. It always seemed like he knew more than he let on, though".</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/resources/levels.php
+++ b/html/resources/levels.php
@@ -57,7 +57,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Levels, Experience Requirements, Mastery and Ascension Levels</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#summary">Summary</a></p>
@@ -629,7 +629,7 @@ include PROJECT_ROOT . "/html/header.php";
     }
     if ($username != "") {
         echo("<p>Initial values are based on replays you have uploaded to this site.</p>");
-        include("../scripts/sqlconnection.php");
+        include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
         $sql = "SELECT server, mycommander, commanderlevel, masterylevel, prestige from userreplays
                     WHERE username='$username'
                     ORDER BY played ASC";

--- a/html/resources/levels.php
+++ b/html/resources/levels.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Levels</title>
   <meta name="description" content="A list of experience brackets in Starcraft II Co-op, as well as a few calculators to show you how far you are through Ascension levels.">
@@ -54,10 +54,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Levels, Experience Requirements, Mastery and Ascension Levels</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#summary">Summary</a></p>
@@ -629,7 +629,7 @@ include PROJECT_ROOT . "/html/header.php";
     }
     if ($username != "") {
         echo("<p>Initial values are based on replays you have uploaded to this site.</p>");
-        include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+        include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
         $sql = "SELECT server, mycommander, commanderlevel, masterylevel, prestige from userreplays
                     WHERE username='$username'
                     ORDER BY played ASC";
@@ -1106,7 +1106,7 @@ include PROJECT_ROOT . "/html/header.php";
         });
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/levels.php
+++ b/html/resources/levels.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Levels</title>
   <meta name="description" content="A list of experience brackets in Starcraft II Co-op, as well as a few calculators to show you how far you are through Ascension levels.">
@@ -54,7 +54,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Levels, Experience Requirements, Mastery and Ascension Levels</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -1106,7 +1106,7 @@ include("../header.php");
         });
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -83,7 +83,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mutators List: Names, Icons, Descriptions and Mechanics</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#safetyZones">Safety Zone</a></p>
@@ -168,7 +168,7 @@ include PROJECT_ROOT . "/html/header.php";
     </div>
     <h2 id="mutatorInteractions">Mutator Interactions</h2>
     <?php
-    include '../scripts/sqlconnection.php';
+    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
     $sql = "SELECT mutatorname, mutatorid
             FROM mutators
             ORDER BY mutatorname ASC";

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Mutator List</title>
   <meta name="description" content="A list of all mutators in Starcraft II Co-op, along with detailed descriptions of their mechanics and commander-specific tips.">
@@ -80,10 +80,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Mutators List: Names, Icons, Descriptions and Mechanics</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <div id="links">
         <h2>Sections on this Page</h2>
         <p><a href="#safetyZones">Safety Zone</a></p>
@@ -168,7 +168,7 @@ include PROJECT_ROOT . "/html/header.php";
     </div>
     <h2 id="mutatorInteractions">Mutator Interactions</h2>
     <?php
-    include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+    include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
     $sql = "SELECT mutatorname, mutatorid
             FROM mutators
             ORDER BY mutatorname ASC";
@@ -3837,7 +3837,7 @@ include PROJECT_ROOT . "/html/header.php";
         })
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Mutator List</title>
   <meta name="description" content="A list of all mutators in Starcraft II Co-op, along with detailed descriptions of their mechanics and commander-specific tips.">
@@ -80,7 +80,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Mutators List: Names, Icons, Descriptions and Mechanics</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -3837,7 +3837,7 @@ include("../header.php");
         })
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/patchdata.php
+++ b/html/resources/patchdata.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Patch Data</title>
   <meta name="description" content="Data-mined patch data for the latest Starcraft II Co-op Patch. This page contains both, official and hidden patch changes.">
@@ -14,7 +14,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Starcraft Co-op Patch Data</h1>
     <div id="links">
@@ -121,7 +121,7 @@ include("../header.php");
         <li><span class="hidden">Modified regular Transmission to Victory Tranmission on mission Victory.</span></li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/patchdata.php
+++ b/html/resources/patchdata.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Patch Data</title>
   <meta name="description" content="Data-mined patch data for the latest Starcraft II Co-op Patch. This page contains both, official and hidden patch changes.">
@@ -14,7 +14,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Starcraft Co-op Patch Data</h1>
     <div id="links">
@@ -121,7 +121,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li><span class="hidden">Modified regular Transmission to Victory Tranmission on mission Victory.</span></li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/resources/weeklymutations.php
+++ b/html/resources/weeklymutations.php
@@ -378,7 +378,7 @@ include PROJECT_ROOT . "/html/header.php";
     <ul>
         <?php
 
-        include '../scripts/sqlconnection.php';
+        include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
 
         $sql = "SELECT mutatorid, mutatorname, mutatordescription, abomination
                     FROM mutators

--- a/html/resources/weeklymutations.php
+++ b/html/resources/weeklymutations.php
@@ -1,5 +1,5 @@
 <?php
-include("../header.php");
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Weekly Mutations</title>
   <meta name="description" content="Starcraft 2 Co-op Weekly Mutations">
@@ -336,7 +336,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>A List of Weekly Mutations With Difficulties</h1>
     <div id="links">
@@ -897,7 +897,7 @@ include("../header.php");
         });
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/resources/weeklymutations.php
+++ b/html/resources/weeklymutations.php
@@ -1,5 +1,5 @@
 <?php
-include PROJECT_ROOT . "/html/header.php";
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Weekly Mutations</title>
   <meta name="description" content="Starcraft 2 Co-op Weekly Mutations">
@@ -336,7 +336,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>A List of Weekly Mutations With Difficulties</h1>
     <div id="links">
@@ -378,7 +378,7 @@ include PROJECT_ROOT . "/html/header.php";
     <ul>
         <?php
 
-        include PROJECT_ROOT . "/html/scripts/sqlconnection.php";
+        include PROJECT_ROOT . '/html/scripts/sqlconnection.php';
 
         $sql = "SELECT mutatorid, mutatorname, mutatordescription, abomination
                     FROM mutators
@@ -897,7 +897,7 @@ include PROJECT_ROOT . "/html/header.php";
         });
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/scripts/calculatebreakpoints.php
+++ b/html/scripts/calculatebreakpoints.php
@@ -163,7 +163,7 @@ if (isset($_POST['ability'])) {
         if ($structure == 0) {
             $appendString .= " and structure='0'";
         }
-        include("sqlconnection.php");
+        include 'sqlconnection.php';
         $sql = "SELECT name, race, hp+shields as vitality, light,structure
                   FROM amonunits
                   WHERE breakpoint='1' $appendString

--- a/html/scripts/calculatestats.php
+++ b/html/scripts/calculatestats.php
@@ -890,7 +890,7 @@ function getUnitUpgradesOutput($commander, $unit)
     }
     $con->close();
 
-    require_once __DIR__ . '/../data/queries.php';
+    require_once PROJECT_ROOT . '/html/data/queries.php';
 
     $commanderData = get_commander($commander);
     $commanderPrestiges = [

--- a/html/scripts/generatemutation.php
+++ b/html/scripts/generatemutation.php
@@ -16,7 +16,7 @@ if ($difficulty < 1 || $difficulty > 6) {
     die();
 }
 
-require_once __DIR__ . '/../data/queries.php';
+require_once PROJECT_ROOT . '/html/data/queries.php';
 
 $oneBrutal = get_brutalplus($difficulty);
 $minMutators = $oneBrutal['minmutators'];

--- a/html/scripts/refreshcommunitystats.php
+++ b/html/scripts/refreshcommunitystats.php
@@ -1,6 +1,6 @@
 <?php
 
-include("sqlconnection.php");
+include 'sqlconnection.php';
 
 //Globals
 $rushableMissions = ["Chain of Ascension", "Cradle of Death", "Dead of Night", "Lock & Load", "Miner Evacuation", "Part and Parcel", "Rifts to Korhal", "Scythe of Amon", "Void Thrashing"];

--- a/html/scripts/sqlconnection.php
+++ b/html/scripts/sqlconnection.php
@@ -1,5 +1,6 @@
 <?php
 
+global $DB_HOST, $DB_USER, $DB_PASS, $DB_NAME;
 $con = new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
 if ($con->connect_error) {
     die("Connection failed: " . $con->connect_error);

--- a/html/scripts/sqlconnection.php
+++ b/html/scripts/sqlconnection.php
@@ -1,7 +1,5 @@
 <?php
 
-require __DIR__ . "/../../config.php";
-
 $con = new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
 if ($con->connect_error) {
     die("Connection failed: " . $con->connect_error);

--- a/html/tools/downloads.php
+++ b/html/tools/downloads.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Downloads</title>
   <meta name="description" content="A list of free tools and software for community use. Some programming experience will be required in order to utilize the code provided.">
@@ -17,7 +17,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Downloads (Co-op Assistant and Replay Parsing Script)</h1>
     <div id="links">
@@ -238,7 +238,7 @@ include("../header.php");
         <li>Map names will be affected by language localization. That is, the map names will be displayed in the language the game was played in when the replay was created.</li>
     </ul>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>
 

--- a/html/tools/downloads.php
+++ b/html/tools/downloads.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Downloads</title>
   <meta name="description" content="A list of free tools and software for community use. Some programming experience will be required in order to utilize the code provided.">
@@ -17,7 +17,7 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Downloads (Co-op Assistant and Replay Parsing Script)</h1>
     <div id="links">
@@ -238,7 +238,7 @@ include PROJECT_ROOT . "/html/header.php";
         <li>Map names will be affected by language localization. That is, the map names will be displayed in the language the game was played in when the replay was created.</li>
     </ul>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>
 

--- a/html/tools/masterybreakpoints.php
+++ b/html/tools/masterybreakpoints.php
@@ -71,7 +71,7 @@ include PROJECT_ROOT . "/html/header.php";
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Mastery Breakpoints Calculator</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <p>You may use the calculator below to determine what mastery allocation you require to kill various units in Amon's forces. Note that objectives, Infested units and Mutator units are not taken into consideration. Move the slider left and right to allocate mastery points, and the units above the slider will move to show you which can be killed and which can't.</p>
     <div id="input">
         <h2>Select the Ability/Damage Type</h2>

--- a/html/tools/masterybreakpoints.php
+++ b/html/tools/masterybreakpoints.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Mastery Breakpoints Calculator</title>
   <meta name="description" content="Figure out how many mastery points you need to reach certain breakpoints with this calculator.">
@@ -67,7 +67,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Mastery Breakpoints Calculator</h1>
@@ -378,6 +378,6 @@ include("../header.php");
         }
     </script>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/tools/masterybreakpoints.php
+++ b/html/tools/masterybreakpoints.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Mastery Breakpoints Calculator</title>
   <meta name="description" content="Figure out how many mastery points you need to reach certain breakpoints with this calculator.">
@@ -67,11 +67,11 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <div id="tooltip">tooltip</div>
     <h1>Mastery Breakpoints Calculator</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <p>You may use the calculator below to determine what mastery allocation you require to kill various units in Amon's forces. Note that objectives, Infested units and Mutator units are not taken into consideration. Move the slider left and right to allocate mastery points, and the units above the slider will move to show you which can be killed and which can't.</p>
     <div id="input">
         <h2>Select the Ability/Damage Type</h2>
@@ -378,6 +378,6 @@ include PROJECT_ROOT . "/html/header.php";
         }
     </script>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/tools/replayanalyzer.php
+++ b/html/tools/replayanalyzer.php
@@ -1,16 +1,16 @@
 <?php
 http_response_code(410);
 
-include PROJECT_ROOT . "/html/header.php";
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Replay Analyzer</title>
 </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>Co-op Replay Analyzer</h1>
     <p>Sorry, the replay analyzer is no longer available.</p>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/tools/replayanalyzer.php
+++ b/html/tools/replayanalyzer.php
@@ -1,16 +1,16 @@
 <?php
 http_response_code(410);
 
-include("../header.php");
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Replay Analyzer</title>
 </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>Co-op Replay Analyzer</h1>
     <p>Sorry, the replay analyzer is no longer available.</p>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>

--- a/html/tools/unitstats.php
+++ b/html/tools/unitstats.php
@@ -226,7 +226,7 @@ include PROJECT_ROOT . "/html/header.php";
 <?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>A List of Unit Stats for Player and Amon Units</h1>
-    <?php include("../scripts/reporterror.php");?>
+    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
     <h2>Unit Comparison</h2>
     <p>Use the below applet to see single unit stats or compare two units together. Click on a commander, then a unit of theirs to get its stats. To compare two units, select a commander and their unit on the opposite side.</p>
     <p>Notes about the data:</p>

--- a/html/tools/unitstats.php
+++ b/html/tools/unitstats.php
@@ -1,7 +1,7 @@
 <?php
 
-require PROJECT_ROOT . "/html/admin-only.php";
-include PROJECT_ROOT . "/html/header.php";
+require PROJECT_ROOT . '/html/admin-only.php';
+include PROJECT_ROOT . '/html/header.php';
 ?>
   <title>Starcraft 2 Co-op - Unit Stats</title>
   <meta name="description" content="A calculator to provide you with unit stats before and after upgrades for every unit in Co-op. Also includes data on Amon's units.">
@@ -223,10 +223,10 @@ include PROJECT_ROOT . "/html/header.php";
   </style>
   </head>
 <body>
-<?php include PROJECT_ROOT . "/html/menu.php"; ?>
+<?php include PROJECT_ROOT . '/html/menu.php'; ?>
 <div id="content">
     <h1>A List of Unit Stats for Player and Amon Units</h1>
-    <?php include PROJECT_ROOT . "/html/scripts/reporterror.php"; ?>
+    <?php include PROJECT_ROOT . '/html/scripts/reporterror.php'; ?>
     <h2>Unit Comparison</h2>
     <p>Use the below applet to see single unit stats or compare two units together. Click on a commander, then a unit of theirs to get its stats. To compare two units, select a commander and their unit on the opposite side.</p>
     <p>Notes about the data:</p>
@@ -489,7 +489,7 @@ include PROJECT_ROOT . "/html/header.php";
     <div id="dataContainer"></div>
     <div id="amonTableContainer">
         <div id="flexContainer">
-            <?php include("../scripts/generatetable.php");?>
+            <?php include PROJECT_ROOT . '/html/scripts/generatetable.php'; ?>
         </div>
     </div>
     <script>
@@ -549,6 +549,6 @@ include PROJECT_ROOT . "/html/header.php";
     </script>
     <div class="clear"></div>
 </div>
-<?php include PROJECT_ROOT . "/html/footer.php"; ?>
+<?php include PROJECT_ROOT . '/html/footer.php'; ?>
 </body>
 </html>

--- a/html/tools/unitstats.php
+++ b/html/tools/unitstats.php
@@ -1,7 +1,7 @@
 <?php
 
-require "../admin-only.php";
-include("../header.php");
+require PROJECT_ROOT . "/html/admin-only.php";
+include PROJECT_ROOT . "/html/header.php";
 ?>
   <title>Starcraft 2 Co-op - Unit Stats</title>
   <meta name="description" content="A calculator to provide you with unit stats before and after upgrades for every unit in Co-op. Also includes data on Amon's units.">
@@ -223,7 +223,7 @@ include("../header.php");
   </style>
   </head>
 <body>
-<?php include("../menu.php"); ?>
+<?php include PROJECT_ROOT . "/html/menu.php"; ?>
 <div id="content">
     <h1>A List of Unit Stats for Player and Amon Units</h1>
     <?php include("../scripts/reporterror.php");?>
@@ -549,6 +549,6 @@ include("../header.php");
     </script>
     <div class="clear"></div>
 </div>
-<?php include("../footer.php"); ?>
+<?php include PROJECT_ROOT . "/html/footer.php"; ?>
 </body>
 </html>


### PR DESCRIPTION
Add global `PROJECT_ROOT` for use in absolute includes

Add root level `.htaccess.example` file to always include `config.php`
git-ignore actual root level `.htaccess` file
Absolute inclusion paths for :
  - header, footer, menu, admin-only
  - sqlconnection, reporterror, queries
  - switchergenerator, generatetable

For includes in the same folder, like scripts/*.php which use
  scripts/sqlconnection.php, the inclusion remains as-is.
  (but this is slightly inconsistent)

Use single quotes and no parentheses consistently in includes
