### PR TITLE
Fix empty results when no interactions & show all

### DIFF
--- a/html/resources/mutators.html
+++ b/html/resources/mutators.html
@@ -529,7 +529,7 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                     var filename = mutators[key].replace(/ /g,'').toLowerCase();
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
-                $("#interactions").html(html);
+                $("#interactions").html(html || "No interaction found.");
             } else if (mut1 && mut2) {
                 $("#interactions").text(getInteraction(mut1, mut2) || "No interaction found.");
             } else if (mut1 && !$mut2.length) {

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -278,7 +278,7 @@ require_once "../wrapper-static.php";
                     var filename = mutators[key].replace(/ /g,'').toLowerCase();
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
-                $("#interactions").html(html);
+                $("#interactions").html(html || "No interaction found.");
             } else if (mut1 && mut2) {
                 $("#interactions").text(getInteraction(mut1, mut2) || "No interaction found.");
             } else if (mut1 && !$mut2.length) {


### PR DESCRIPTION
When the first mutator has no interactions and we select 'show all interactions' in the second dropdown, the result html is empty.
For 'show all', default to 'No interaction found.' if empty.

In reverse, it already works fine - we can select a non-interacting mutator in the second dropdown and then any mutator in the first since they are all enabled.