### PR TITLE
Human-ish ids for mutatorinteractions

### DIFF
--- a/html/data/mutatorinteractions.json
+++ b/html/data/mutatorinteractions.json
@@ -795,8 +795,8 @@
         "interaction": "Infested apply the Concussive Attacks debuff."
     },
     {
-        "id1": "concussiveattacks",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "concussiveattacks",
         "interaction": "Boom Bots apply the Concussive Attacks debuff."
     },
     {
@@ -845,8 +845,8 @@
         "interaction": "Void Rifts are marked on the minimap."
     },
     {
-        "id1": "darkness",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "darkness",
         "interaction": "Boom Bots do not appear on the minimap."
     },
     {
@@ -955,8 +955,8 @@
         "interaction": "Void Reanimators spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": "eminentdomain",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "eminentdomain",
         "interaction": "Boom Bots spawn out of structures converted by Eminent Domain."
     },
     {
@@ -1115,8 +1115,8 @@
         "interaction": "Infested trigger Fatal Attraction when they die."
     },
     {
-        "id1": "fatalattraction",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "fatalattraction",
         "interaction": "Boom Bots trigger Fatal Attraction when they die."
     },
     {
@@ -1240,8 +1240,8 @@
         "interaction": "Infested can apply the Fear effect."
     },
     {
-        "id1": "fear",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "fear",
         "interaction": "Boom Bots do not apply the Fear effect."
     },
     {
@@ -1310,8 +1310,8 @@
         "interaction": "Infested do not launch Fireworks when they die."
     },
     {
-        "id1": "fireworks",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "fireworks",
         "interaction": "Boom Bots launch Fireworks when they die."
     },
     {
@@ -1475,8 +1475,8 @@
         "interaction": "Units spawned from Gift Exchange are cloaked."
     },
     {
-        "id1": "giftexchange",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "giftexchange",
         "interaction": "Boom Bots do not capture gifts."
     },
     {
@@ -1550,8 +1550,8 @@
         "interaction": "Infested cause Hardened Will to activate."
     },
     {
-        "id1": "hardenedwill",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "hardenedwill",
         "interaction": "Boom Bots do not get the Hardened Will buff."
     },
     {
@@ -1680,8 +1680,8 @@
         "interaction": "Infested can get the Inspiration buff."
     },
     {
-        "id1": "inspiration",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "inspiration",
         "interaction": "Boom Bots do not provide the Inspiration buff."
     },
     {
@@ -1790,8 +1790,8 @@
         "interaction": "Respawned units are cloaked."
     },
     {
-        "id1": "justdie",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "justdie",
         "interaction": "Boom Bots do not respawn when they self-destruct."
     },
     {
@@ -1955,8 +1955,8 @@
         "interaction": "Infested provide vision for the Laser Drill."
     },
     {
-        "id1": "laserdrill",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "laserdrill",
         "interaction": "Boom Bots provide vision for the Laser Drill.\r\nBoom Bots do not spawn from the Laser Drill."
     },
     {
@@ -2220,8 +2220,8 @@
         "interaction": "Hybrids spawned from Void Rifts trigger Moment of Silence when they die."
     },
     {
-        "id1": "momentofsilence",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "momentofsilence",
         "interaction": "Boom Bots do not trigger Moment of Silence when they die."
     },
     {
@@ -2400,8 +2400,8 @@
         "interaction": "Infested can cast abilities."
     },
     {
-        "id1": "poweroverwhelming",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "poweroverwhelming",
         "interaction": "Boom Bots can cast abilities. Boom Bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
@@ -2480,8 +2480,8 @@
         "interaction": "Infested set the ground on fire when they die."
     },
     {
-        "id1": "scorchedearth",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "scorchedearth",
         "interaction": "Boom Bots set the ground on fire when they die."
     },
     {
@@ -2510,8 +2510,8 @@
         "interaction": "Infested create an explosion when they die."
     },
     {
-        "id1": "selfdestruction",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "selfdestruction",
         "interaction": "Boom Bots create an explosion when they die."
     },
     {
@@ -2545,8 +2545,8 @@
         "interaction": "Infested units move faster with Speed Freaks."
     },
     {
-        "id1": "speedfreaks",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "speedfreaks",
         "interaction": "Boom Bots move faster with Speed Freaks."
     },
     {
@@ -2645,8 +2645,8 @@
         "interaction": "Void Reanimators are cloaked."
     },
     {
-        "id1": "voidreanimators",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not resurrect Boom Bots."
     },
     {
@@ -2660,8 +2660,8 @@
         "interaction": "Units spawned from Void Rifts are cloaked."
     },
     {
-        "id1": "voidrifts",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "voidrifts",
         "interaction": "Boom Bots do not spawn from Void Rifts."
     },
     {
@@ -2670,13 +2670,13 @@
         "interaction": "Infested are cloaked."
     },
     {
-        "id1": "walkinginfested",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "walkinginfested",
         "interaction": "Boom Bots spawn Infested when they die."
     },
     {
-        "id1": "wemoveunseen",
-        "id2": "boombots",
+        "id1": "boombots",
+        "id2": "wemoveunseen",
         "interaction": "Boom Bots are cloaked, but their tags are still visible.\r\nCodes cannot be input without detection."
     }
 ]

--- a/html/data/mutatorinteractions.json
+++ b/html/data/mutatorinteractions.json
@@ -21,7 +21,7 @@
     },
     {
         "id1": "afraidofthedark",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines appear on the minimap."
     },
     {
@@ -261,7 +261,7 @@
     },
     {
         "id1": "alienincubation",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines do not spawn Broodlings when they detonate."
     },
     {
@@ -381,7 +381,7 @@
     },
     {
         "id1": "avenger",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines do not give out Avenger stacks when they detonate."
     },
     {
@@ -556,7 +556,7 @@
     },
     {
         "id1": "blackdeath",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines cannot carry Plague."
     },
     {
@@ -706,7 +706,7 @@
     },
     {
         "id1": "concussiveattacks",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mines apply the Concussive Attacks debuff."
     },
     {
@@ -816,7 +816,7 @@
     },
     {
         "id1": "darkness",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines appear on the minimap."
     },
     {
@@ -1051,7 +1051,7 @@
     },
     {
         "id1": "fatalattraction",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines trigger Fatal Attraction when they detonate."
     },
     {
@@ -1161,7 +1161,7 @@
     },
     {
         "id1": "fear",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mines can apply the Fear effect."
     },
     {
@@ -1261,7 +1261,7 @@
     },
     {
         "id1": "fireworks",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mines do not launch Fireworks when they explode."
     },
     {
@@ -1361,7 +1361,7 @@
     },
     {
         "id1": "giftexchange",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines can capture gifts."
     },
     {
@@ -1496,7 +1496,7 @@
     },
     {
         "id1": "hardenedwill",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines do not cause Hardened Will to activate."
     },
     {
@@ -1696,7 +1696,7 @@
     },
     {
         "id1": "justdie",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines do not respawn when they explode."
     },
     {
@@ -1866,7 +1866,7 @@
     },
     {
         "id1": "laserdrill",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines provide vision for the Laser Drill."
     },
     {
@@ -2001,7 +2001,7 @@
     },
     {
         "id1": "longrange",
-        "id2": "magnificent",
+        "id2": "mag-nificent",
         "interaction": "Mag-mines do not get the Long Range buff."
     },
     {
@@ -2050,42 +2050,42 @@
         "interaction": "Units spawned from Void Rifts get the Long Range buff."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "poweroverwhelming",
         "interaction": "Mag-mines cannot cast abilities."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "scorchedearth",
         "interaction": "Mag-mines do not set the ground on fire when they explode."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "selfdestruction",
         "interaction": "Mag-mines do not create an explosion when explode."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "speedfreaks",
         "interaction": "Mag-mines do not move faster with Speed Freaks."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "transmutation",
         "interaction": "Mag-mines do not Transmute after killing a unit."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "voidreanimators",
         "interaction": "Void Reanimators do not resurrect Mag-mines."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "walkinginfested",
         "interaction": "Mag-mines do not spawn Infested when they detonate."
     },
     {
-        "id1": "magnificent",
+        "id1": "mag-nificent",
         "id2": "wemoveunseen",
         "interaction": "Mag-mines are cloaked."
     },

--- a/html/data/mutatorinteractions.json
+++ b/html/data/mutatorinteractions.json
@@ -1,2682 +1,2682 @@
 [
     {
-        "id1": 1,
-        "id2": 7,
+        "id1": "afraidofthedark",
+        "id2": "blizzard",
         "interaction": "Blizzards appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 18,
+        "id1": "afraidofthedark",
+        "id2": "giftexchange",
         "interaction": "Gifts do not appear on the minimap. Kill Bots gifted to Amon do not appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 24,
+        "id1": "afraidofthedark",
+        "id2": "killbots",
         "interaction": "Kill Bots do not appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 25,
+        "id1": "afraidofthedark",
+        "id2": "laserdrill",
         "interaction": "The Laser Drill will be marked on the minimap when it attacks you."
     },
     {
-        "id1": 1,
-        "id2": 30,
+        "id1": "afraidofthedark",
+        "id2": "magnificent",
         "interaction": "Mag-mines appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 34,
+        "id1": "afraidofthedark",
+        "id2": "missilecommand",
         "interaction": "Missiles do not appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 43,
+        "id1": "afraidofthedark",
+        "id2": "propagators",
         "interaction": "Propagators do not appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 44,
+        "id1": "afraidofthedark",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam appears as a red dot on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 56,
+        "id1": "afraidofthedark",
+        "id2": "turkeyshoot",
         "interaction": "The Turking does not appear on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 60,
+        "id1": "afraidofthedark",
+        "id2": "voidrifts",
         "interaction": "Void Rifts are marked on the minimap."
     },
     {
-        "id1": 1,
-        "id2": 63,
+        "id1": "afraidofthedark",
+        "id2": "boombots",
         "interaction": "Boom Bots do not appear on the minimap."
     },
     {
-        "id1": 2,
-        "id2": 3,
+        "id1": "aggressivedeployment",
+        "id2": "alienincubation",
         "interaction": "Units from Aggressive Deployment Drops spawn Broodlings when they die."
     },
     {
-        "id1": 2,
-        "id2": 4,
+        "id1": "aggressivedeployment",
+        "id2": "avenger",
         "interaction": "Units from Aggressive Deployment Drops give out and receive Avenger stacks."
     },
     {
-        "id1": 2,
-        "id2": 5,
+        "id1": "aggressivedeployment",
+        "id2": "barrier",
         "interaction": "Units from Aggressive Deployment Drops get the Barrier buff."
     },
     {
-        "id1": 2,
-        "id2": 6,
+        "id1": "aggressivedeployment",
+        "id2": "blackdeath",
         "interaction": "Units from Aggressive Deployment Drops can carry Plague."
     },
     {
-        "id1": 2,
-        "id2": 8,
+        "id1": "aggressivedeployment",
+        "id2": "chaosstudios",
         "interaction": "A single 1/1 Aggressive Deployment drop will spawn once the mutator rolls out."
     },
     {
-        "id1": 2,
-        "id2": 9,
+        "id1": "aggressivedeployment",
+        "id2": "concussiveattacks",
         "interaction": "Units from Aggressive Deployment Drops apply the Concussive Attacks debuff."
     },
     {
-        "id1": 2,
-        "id2": 14,
+        "id1": "aggressivedeployment",
+        "id2": "evasivemaneuvers",
         "interaction": "Units from Aggressive Deployment Drops get the Evasive Maneuvers buff."
     },
     {
-        "id1": 2,
-        "id2": 15,
+        "id1": "aggressivedeployment",
+        "id2": "fatalattraction",
         "interaction": "Units from Aggressive Deployment Drops trigger Fatal Attraction when they die."
     },
     {
-        "id1": 2,
-        "id2": 16,
+        "id1": "aggressivedeployment",
+        "id2": "fear",
         "interaction": "Units from Aggressive Deployment Drops can apply the Fear effect."
     },
     {
-        "id1": 2,
-        "id2": 17,
+        "id1": "aggressivedeployment",
+        "id2": "fireworks",
         "interaction": "Units from Aggressive Deployment Drops do not launch Fireworks when they die."
     },
     {
-        "id1": 2,
-        "id2": 18,
+        "id1": "aggressivedeployment",
+        "id2": "giftexchange",
         "interaction": "Units from Aggressive Deployment Drops can capture gifts."
     },
     {
-        "id1": 2,
-        "id2": 20,
+        "id1": "aggressivedeployment",
+        "id2": "hardenedwill",
         "interaction": "Units from Aggressive Deployment Drops cause Hardened Will to activate."
     },
     {
-        "id1": 2,
-        "id2": 21,
+        "id1": "aggressivedeployment",
+        "id2": "heroesfromthestorm",
         "interaction": "Aggressive Deployment drops do not contain Amon Heroes."
     },
     {
-        "id1": 2,
-        "id2": 22,
+        "id1": "aggressivedeployment",
+        "id2": "inspiration",
         "interaction": "Units from Aggressive Deployment Drops can get the Inspiration buff."
     },
     {
-        "id1": 2,
-        "id2": 23,
+        "id1": "aggressivedeployment",
+        "id2": "justdie",
         "interaction": "Units from Aggressive Deployment Drops respawn when they die."
     },
     {
-        "id1": 2,
-        "id2": 27,
+        "id1": "aggressivedeployment",
+        "id2": "lifeleech",
         "interaction": "Units from Aggressive Deployment Drops have the Life Leech buff."
     },
     {
-        "id1": 2,
-        "id2": 28,
+        "id1": "aggressivedeployment",
+        "id2": "longrange",
         "interaction": "Units from Aggressive Deployment Drops get the Long Range buff."
     },
     {
-        "id1": 2,
-        "id2": 37,
+        "id1": "aggressivedeployment",
+        "id2": "naughtylist",
         "interaction": "Aggressive Deployment Drop kills increase the Naughty List count."
     },
     {
-        "id1": 2,
-        "id2": 41,
+        "id1": "aggressivedeployment",
+        "id2": "polarity",
         "interaction": "Units from Aggressive Deployment Drops all have Polarity applied to them."
     },
     {
-        "id1": 2,
-        "id2": 42,
+        "id1": "aggressivedeployment",
+        "id2": "poweroverwhelming",
         "interaction": "Units from Aggressive Deployment Drops move can cast skills."
     },
     {
-        "id1": 2,
-        "id2": 46,
+        "id1": "aggressivedeployment",
+        "id2": "scorchedearth",
         "interaction": "Units from Aggressive Deployment Drops set the ground on fire when they die."
     },
     {
-        "id1": 2,
-        "id2": 47,
+        "id1": "aggressivedeployment",
+        "id2": "selfdestruction",
         "interaction": "Units from Aggressive Deployment Drops create an explosion when they die."
     },
     {
-        "id1": 2,
-        "id2": 51,
+        "id1": "aggressivedeployment",
+        "id2": "speedfreaks",
         "interaction": "Units from Aggressive Deployment Drops move faster with Speed Freaks."
     },
     {
-        "id1": 2,
-        "id2": 54,
+        "id1": "aggressivedeployment",
+        "id2": "transmutation",
         "interaction": "Units from Aggressive Deployment Drops can Transmute."
     },
     {
-        "id1": 2,
-        "id2": 59,
+        "id1": "aggressivedeployment",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can resurrect units from Aggressive Deployment Drops."
     },
     {
-        "id1": 2,
-        "id2": 61,
+        "id1": "aggressivedeployment",
+        "id2": "walkinginfested",
         "interaction": "Units from Aggressive Deployment Drops spawn Infested when they die."
     },
     {
-        "id1": 2,
-        "id2": 62,
+        "id1": "aggressivedeployment",
+        "id2": "wemoveunseen",
         "interaction": "Units from Aggressive Deployment Drops are cloaked."
     },
     {
-        "id1": 3,
-        "id2": 4,
+        "id1": "alienincubation",
+        "id2": "avenger",
         "interaction": "Broodlings can give out/receive Avenger stacks."
     },
     {
-        "id1": 3,
-        "id2": 5,
+        "id1": "alienincubation",
+        "id2": "barrier",
         "interaction": "Broodlings get the Barrier buff."
     },
     {
-        "id1": 3,
-        "id2": 6,
+        "id1": "alienincubation",
+        "id2": "blackdeath",
         "interaction": "Broodlings can carry Plague."
     },
     {
-        "id1": 3,
-        "id2": 14,
+        "id1": "alienincubation",
+        "id2": "evasivemaneuvers",
         "interaction": "Broodlings get the Evasive Maneuvers buff."
     },
     {
-        "id1": 3,
-        "id2": 15,
+        "id1": "alienincubation",
+        "id2": "fatalattraction",
         "interaction": "Broodlings trigger Fatal Attraction when they die."
     },
     {
-        "id1": 3,
-        "id2": 16,
+        "id1": "alienincubation",
+        "id2": "fear",
         "interaction": "Broodlings can apply the Fear effect."
     },
     {
-        "id1": 3,
-        "id2": 17,
+        "id1": "alienincubation",
+        "id2": "fireworks",
         "interaction": "Broodlings launch Fireworks when they die."
     },
     {
-        "id1": 3,
-        "id2": 18,
+        "id1": "alienincubation",
+        "id2": "giftexchange",
         "interaction": "Broodlings can capture gifts. Units spawned from Gift Exchange spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 20,
+        "id1": "alienincubation",
+        "id2": "hardenedwill",
         "interaction": "Broodlings cause Hardened Will to activate."
     },
     {
-        "id1": 3,
-        "id2": 21,
+        "id1": "alienincubation",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 22,
+        "id1": "alienincubation",
+        "id2": "inspiration",
         "interaction": "Broodlings can get the Inspiration buff."
     },
     {
-        "id1": 3,
-        "id2": 23,
+        "id1": "alienincubation",
+        "id2": "justdie",
         "interaction": "Broodlings respawn when they die."
     },
     {
-        "id1": 3,
-        "id2": 24,
+        "id1": "alienincubation",
+        "id2": "killbots",
         "interaction": "Kill Bots spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 27,
+        "id1": "alienincubation",
+        "id2": "lifeleech",
         "interaction": "Broodlings have Life Leech."
     },
     {
-        "id1": 3,
-        "id2": 30,
+        "id1": "alienincubation",
+        "id2": "magnificent",
         "interaction": "Mag-mines do not spawn Broodlings when they detonate."
     },
     {
-        "id1": 3,
-        "id2": 33,
+        "id1": "alienincubation",
+        "id2": "minesweeper",
         "interaction": "Mines spawn Broodlings when they are destroyed."
     },
     {
-        "id1": 3,
-        "id2": 34,
+        "id1": "alienincubation",
+        "id2": "missilecommand",
         "interaction": "Missiles do not spawn Broodlings when destroyed."
     },
     {
-        "id1": 3,
-        "id2": 37,
+        "id1": "alienincubation",
+        "id2": "naughtylist",
         "interaction": "Broodling kills increase the Naughty List count."
     },
     {
-        "id1": 3,
-        "id2": 39,
+        "id1": "alienincubation",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations do not spawn Broodlings units when killed."
     },
     {
-        "id1": 3,
-        "id2": 41,
+        "id1": "alienincubation",
+        "id2": "polarity",
         "interaction": "Broodlings all have Polarity applied to them."
     },
     {
-        "id1": 3,
-        "id2": 42,
+        "id1": "alienincubation",
+        "id2": "poweroverwhelming",
         "interaction": "Broodlings can cast abilities."
     },
     {
-        "id1": 3,
-        "id2": 43,
+        "id1": "alienincubation",
+        "id2": "propagators",
         "interaction": "Propagators spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 46,
+        "id1": "alienincubation",
+        "id2": "scorchedearth",
         "interaction": "Broodlings set the ground on fire when they die."
     },
     {
-        "id1": 3,
-        "id2": 47,
+        "id1": "alienincubation",
+        "id2": "selfdestruction",
         "interaction": "Broodlings create an explosion when they die."
     },
     {
-        "id1": 3,
-        "id2": 51,
+        "id1": "alienincubation",
+        "id2": "speedfreaks",
         "interaction": "Broodlings move faster with Speed Freaks."
     },
     {
-        "id1": 3,
-        "id2": 54,
+        "id1": "alienincubation",
+        "id2": "transmutation",
         "interaction": "Broodlings can transmutate. Newly-transmuted units spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 55,
+        "id1": "alienincubation",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 56,
+        "id1": "alienincubation",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not spawn Broodlings when they die. Angry Turkeys spawn Broodlings when they die. The Turking does not spawn Broodlings when it dies."
     },
     {
-        "id1": 3,
-        "id2": 59,
+        "id1": "alienincubation",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators cannot resurrect Broodlings."
     },
     {
-        "id1": 3,
-        "id2": 60,
+        "id1": "alienincubation",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts spawn Broodlings when they die."
     },
     {
-        "id1": 3,
-        "id2": 61,
+        "id1": "alienincubation",
+        "id2": "walkinginfested",
         "interaction": "Killed units spawn both, Infested and Broodlings at the same time. Infested units and Broodlings do not spawn units on death."
     },
     {
-        "id1": 3,
-        "id2": 62,
+        "id1": "alienincubation",
+        "id2": "wemoveunseen",
         "interaction": "Broodlings are cloaked."
     },
     {
-        "id1": 3,
-        "id2": 63,
+        "id1": "alienincubation",
+        "id2": "boombots",
         "interaction": "Boom Bots spawn Broodlings when they die."
     },
     {
-        "id1": 4,
-        "id2": 18,
+        "id1": "avenger",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange can give out/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 21,
+        "id1": "avenger",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes can give out (1 stack)/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 22,
+        "id1": "avenger",
+        "id2": "inspiration",
         "interaction": "Units with Avenger stacks can get the Inspiration buff."
     },
     {
-        "id1": 4,
-        "id2": 23,
+        "id1": "avenger",
+        "id2": "justdie",
         "interaction": "Units do not give out/lose Avenger stacks when taking fatal damage and respawning. When a unit is finally killed, Avenger stacks are provided to surrounding units. Units retain their Avenger stacks when taking fatal damage and respawning."
     },
     {
-        "id1": 4,
-        "id2": 24,
+        "id1": "avenger",
+        "id2": "killbots",
         "interaction": "Kill Bots can give out Avenger stacks (1 stack) when they die."
     },
     {
-        "id1": 4,
-        "id2": 30,
+        "id1": "avenger",
+        "id2": "magnificent",
         "interaction": "Mag-mines do not give out Avenger stacks when they detonate."
     },
     {
-        "id1": 4,
-        "id2": 33,
+        "id1": "avenger",
+        "id2": "minesweeper",
         "interaction": "Mines can give out Avenger stacks, but cannot receive them."
     },
     {
-        "id1": 4,
-        "id2": 34,
+        "id1": "avenger",
+        "id2": "missilecommand",
         "interaction": "Missiles do not give out Avenger stacks when destroyed."
     },
     {
-        "id1": 4,
-        "id2": 39,
+        "id1": "avenger",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations can give out/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 43,
+        "id1": "avenger",
+        "id2": "propagators",
         "interaction": "Propagators can give out (1 stack)/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 51,
+        "id1": "avenger",
+        "id2": "speedfreaks",
         "interaction": "Units with Avenger stacks move faster with Speed Freaks."
     },
     {
-        "id1": 4,
-        "id2": 54,
+        "id1": "avenger",
+        "id2": "transmutation",
         "interaction": "Units lose their Avenger stacks after they Transmute."
     },
     {
-        "id1": 4,
-        "id2": 55,
+        "id1": "avenger",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians give out and collect Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 56,
+        "id1": "avenger",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not give out Avenger stacks. Angry Turkeys can give out (1 stack)/receive Avenger stacks. The Turking can give out (10 stacks) Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 59,
+        "id1": "avenger",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can give out (3 stacks) Avenger stacks. Resurrected units do not keep their Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 60,
+        "id1": "avenger",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can give out/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 61,
+        "id1": "avenger",
+        "id2": "walkinginfested",
         "interaction": "Infested can give out/receive Avenger stacks."
     },
     {
-        "id1": 4,
-        "id2": 63,
+        "id1": "avenger",
+        "id2": "boombots",
         "interaction": "Boom Bots do not give out Avenger stacks when they die."
     },
     {
-        "id1": 5,
-        "id2": 13,
+        "id1": "barrier",
+        "id2": "eminentdomain",
         "interaction": "Structures captured by Amon get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 18,
+        "id1": "barrier",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 21,
+        "id1": "barrier",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 23,
+        "id1": "barrier",
+        "id2": "justdie",
         "interaction": "If a unit has used its Barrier buff, the respawned unit will not get the Barrier buff. If a unit has not used its Barrier buff, the respawned unit will have the Barrier buff activated when it respawns."
     },
     {
-        "id1": 5,
-        "id2": 32,
+        "id1": "barrier",
+        "id2": "mineralshields",
         "interaction": "Mineral Shields get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 33,
+        "id1": "barrier",
+        "id2": "minesweeper",
         "interaction": "Mines get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 34,
+        "id1": "barrier",
+        "id2": "missilecommand",
         "interaction": "Missiles get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 39,
+        "id1": "barrier",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 41,
+        "id1": "barrier",
+        "id2": "polarity",
         "interaction": "Damage blocked by Polarity still triggers Barrier."
     },
     {
-        "id1": 5,
-        "id2": 43,
+        "id1": "barrier",
+        "id2": "propagators",
         "interaction": "Propagators get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 54,
+        "id1": "barrier",
+        "id2": "transmutation",
         "interaction": "Transmuted units get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 55,
+        "id1": "barrier",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 56,
+        "id1": "barrier",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 59,
+        "id1": "barrier",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators get the Barrier buff. Resurrected units get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 60,
+        "id1": "barrier",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts get the Barrier buff."
     },
     {
-        "id1": 5,
-        "id2": 61,
+        "id1": "barrier",
+        "id2": "walkinginfested",
         "interaction": "Infested get the Barrier buff."
     },
     {
-        "id1": 6,
-        "id2": 12,
+        "id1": "blackdeath",
+        "id2": "doubleedged",
         "interaction": "Units with Black Death will die twice as fast with Double Edged active."
     },
     {
-        "id1": 6,
-        "id2": 16,
+        "id1": "blackdeath",
+        "id2": "fear",
         "interaction": "Plague damage ticks do not have a chance of applying Fear."
     },
     {
-        "id1": 6,
-        "id2": 18,
+        "id1": "blackdeath",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 21,
+        "id1": "blackdeath",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 23,
+        "id1": "blackdeath",
+        "id2": "justdie",
         "interaction": "Whether a unit has Plague or not is retained when it takes fatal damage. Plague only spreads when the unit is finnally killed."
     },
     {
-        "id1": 6,
-        "id2": 24,
+        "id1": "blackdeath",
+        "id2": "killbots",
         "interaction": "Kill Bots cannot carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 30,
+        "id1": "blackdeath",
+        "id2": "magnificent",
         "interaction": "Mag-mines cannot carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 33,
+        "id1": "blackdeath",
+        "id2": "minesweeper",
         "interaction": "Mines can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 34,
+        "id1": "blackdeath",
+        "id2": "missilecommand",
         "interaction": "Missiles cannot carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 39,
+        "id1": "blackdeath",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 43,
+        "id1": "blackdeath",
+        "id2": "propagators",
         "interaction": "Propagators can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 54,
+        "id1": "blackdeath",
+        "id2": "transmutation",
         "interaction": "Transmuted units may or may not carry Plague, irrespective of whether it carried Plague or not before Transmuting."
     },
     {
-        "id1": 6,
-        "id2": 55,
+        "id1": "blackdeath",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 56,
+        "id1": "blackdeath",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys cannot carry Plague. The Turking can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 59,
+        "id1": "blackdeath",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can carry Plague. Resurrected units may or may not carry Plague, irrespective of whether it originally carried Plague or not before it died."
     },
     {
-        "id1": 6,
-        "id2": 60,
+        "id1": "blackdeath",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 61,
+        "id1": "blackdeath",
+        "id2": "walkinginfested",
         "interaction": "Infested can carry Plague."
     },
     {
-        "id1": 6,
-        "id2": 63,
+        "id1": "blackdeath",
+        "id2": "boombots",
         "interaction": "Boom Bots cannot carry Plague."
     },
     {
-        "id1": 7,
-        "id2": 9,
+        "id1": "blizzard",
+        "id2": "concussiveattacks",
         "interaction": "Blizzard applies the Concussive Attacks debuff."
     },
     {
-        "id1": 7,
-        "id2": 10,
+        "id1": "blizzard",
+        "id2": "darkness",
         "interaction": "Blizzards appear on the minimap."
     },
     {
-        "id1": 7,
-        "id2": 16,
+        "id1": "blizzard",
+        "id2": "fear",
         "interaction": "Blizzard can apply the Fear effect."
     },
     {
-        "id1": 7,
-        "id2": 18,
+        "id1": "blizzard",
+        "id2": "giftexchange",
         "interaction": "Blizzards can capture gifts."
     },
     {
-        "id1": 7,
-        "id2": 25,
+        "id1": "blizzard",
+        "id2": "laserdrill",
         "interaction": "Blizzards do not provide vision for the Laser Drill."
     },
     {
-        "id1": 7,
-        "id2": 62,
+        "id1": "blizzard",
+        "id2": "wemoveunseen",
         "interaction": "Blizzards are not cloaked."
     },
     {
-        "id1": 8,
-        "id2": 32,
+        "id1": "chaosstudios",
+        "id2": "mineralshields",
         "interaction": "Mineral Shields will always spawn on all mineral patches."
     },
     {
-        "id1": 8,
-        "id2": 50,
+        "id1": "chaosstudios",
+        "id2": "slimpickings",
         "interaction": "Mineral patches will have their total mineral count permanently reduced, even after Slim Pickings  cycles out."
     },
     {
-        "id1": 8,
-        "id2": 60,
+        "id1": "chaosstudios",
+        "id2": "voidrifts",
         "interaction": "Void Rifts will spawn 2:20 after they are activated, meaning only two spawns will occur."
     },
     {
-        "id1": 9,
-        "id2": 13,
+        "id1": "concussiveattacks",
+        "id2": "eminentdomain",
         "interaction": "Turrets captured by Amon apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 17,
+        "id1": "concussiveattacks",
+        "id2": "fireworks",
         "interaction": "Fireworks apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 18,
+        "id1": "concussiveattacks",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 19,
+        "id1": "concussiveattacks",
+        "id2": "goingnuclear",
         "interaction": "Nukes apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 21,
+        "id1": "concussiveattacks",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 23,
+        "id1": "concussiveattacks",
+        "id2": "justdie",
         "interaction": "Respawned units apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 24,
+        "id1": "concussiveattacks",
+        "id2": "killbots",
         "interaction": "Kill Bots apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 25,
+        "id1": "concussiveattacks",
+        "id2": "laserdrill",
         "interaction": "Laser Drill applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 26,
+        "id1": "concussiveattacks",
+        "id2": "lavaburst",
         "interaction": "Lava Burst applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 30,
+        "id1": "concussiveattacks",
+        "id2": "magnificent",
         "interaction": "Mines apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 33,
+        "id1": "concussiveattacks",
+        "id2": "minesweeper",
         "interaction": "Mines apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 34,
+        "id1": "concussiveattacks",
+        "id2": "missilecommand",
         "interaction": "Missiles apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 36,
+        "id1": "concussiveattacks",
+        "id2": "mutuallyassureddestruction",
         "interaction": "Hybrid Nukes apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 38,
+        "id1": "concussiveattacks",
+        "id2": "orbitalstrike",
         "interaction": "Orbital Strikes apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 39,
+        "id1": "concussiveattacks",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 40,
+        "id1": "concussiveattacks",
+        "id2": "photonoverload",
         "interaction": "Photon Overload applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 42,
+        "id1": "concussiveattacks",
+        "id2": "poweroverwhelming",
         "interaction": "Damaging skills will apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 44,
+        "id1": "concussiveattacks",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 46,
+        "id1": "concussiveattacks",
+        "id2": "scorchedearth",
         "interaction": "Scorched Earth applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 47,
+        "id1": "concussiveattacks",
+        "id2": "selfdestruction",
         "interaction": "Self Destruction applies the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 54,
+        "id1": "concussiveattacks",
+        "id2": "transmutation",
         "interaction": "Transmuted units apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 55,
+        "id1": "concussiveattacks",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 56,
+        "id1": "concussiveattacks",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 57,
+        "id1": "concussiveattacks",
+        "id2": "twister",
         "interaction": "Twisters apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 59,
+        "id1": "concussiveattacks",
+        "id2": "voidreanimators",
         "interaction": "Resurrected units apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 60,
+        "id1": "concussiveattacks",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 61,
+        "id1": "concussiveattacks",
+        "id2": "walkinginfested",
         "interaction": "Infested apply the Concussive Attacks debuff."
     },
     {
-        "id1": 9,
-        "id2": 63,
+        "id1": "concussiveattacks",
+        "id2": "boombots",
         "interaction": "Boom Bots apply the Concussive Attacks debuff."
     },
     {
-        "id1": 10,
-        "id2": 18,
+        "id1": "darkness",
+        "id2": "giftexchange",
         "interaction": "Gifts do not appear on the minimap. Kill Bots gifted to Amon do not appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 24,
+        "id1": "darkness",
+        "id2": "killbots",
         "interaction": "Kill Bots do not appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 25,
+        "id1": "darkness",
+        "id2": "laserdrill",
         "interaction": "The Laser Drill will be marked on the minimap when it attacks you."
     },
     {
-        "id1": 10,
-        "id2": 30,
+        "id1": "darkness",
+        "id2": "magnificent",
         "interaction": "Mag-mines appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 34,
+        "id1": "darkness",
+        "id2": "missilecommand",
         "interaction": "Missiles do not appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 43,
+        "id1": "darkness",
+        "id2": "propagators",
         "interaction": "Propagators do not appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 44,
+        "id1": "darkness",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam appears as a red dot on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 56,
+        "id1": "darkness",
+        "id2": "turkeyshoot",
         "interaction": "The Turking does not appear on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 60,
+        "id1": "darkness",
+        "id2": "voidrifts",
         "interaction": "Void Rifts are marked on the minimap."
     },
     {
-        "id1": 10,
-        "id2": 63,
+        "id1": "darkness",
+        "id2": "boombots",
         "interaction": "Boom Bots do not appear on the minimap."
     },
     {
-        "id1": 11,
-        "id2": 13,
+        "id1": "diffusion",
+        "id2": "eminentdomain",
         "interaction": "Turrets can be captured by Amon if they deal too much damage to themselves."
     },
     {
-        "id1": 11,
-        "id2": 16,
+        "id1": "diffusion",
+        "id2": "fear",
         "interaction": "Damage dealt by Diffusion can trigger Fear."
     },
     {
-        "id1": 11,
-        "id2": 18,
+        "id1": "diffusion",
+        "id2": "giftexchange",
         "interaction": "Diffusion applies to all units spawned from Gift Exchange."
     },
     {
-        "id1": 11,
-        "id2": 27,
+        "id1": "diffusion",
+        "id2": "lifeleech",
         "interaction": "Damage dealt by Diffusion counts as Life Leech for the unit attacked."
     },
     {
-        "id1": 11,
-        "id2": 41,
+        "id1": "diffusion",
+        "id2": "polarity",
         "interaction": "Diffusion damages all units regardless of their Polarity."
     },
     {
-        "id1": 11,
-        "id2": 54,
+        "id1": "diffusion",
+        "id2": "transmutation",
         "interaction": "Damage dealt by Diffusion can trigger Transmutation on enemy units."
     },
     {
-        "id1": 12,
-        "id2": 13,
+        "id1": "doubleedged",
+        "id2": "eminentdomain",
         "interaction": "Turrets can be captured by Amon if they deal too much damage to themselves."
     },
     {
-        "id1": 12,
-        "id2": 16,
+        "id1": "doubleedged",
+        "id2": "fear",
         "interaction": "Damage dealt by Double Edged does not trigger Fear."
     },
     {
-        "id1": 12,
-        "id2": 27,
+        "id1": "doubleedged",
+        "id2": "lifeleech",
         "interaction": "Damage dealt by Double Edged does not trigger Life Leech."
     },
     {
-        "id1": 12,
-        "id2": 54,
+        "id1": "doubleedged",
+        "id2": "transmutation",
         "interaction": "Damage dealt by Double Edged does not trigger Transmutation."
     },
     {
-        "id1": 13,
-        "id2": 16,
+        "id1": "eminentdomain",
+        "id2": "fear",
         "interaction": "Turrets captured by Amon can apply the Fear effect."
     },
     {
-        "id1": 13,
-        "id2": 24,
+        "id1": "eminentdomain",
+        "id2": "killbots",
         "interaction": "Kill Bots spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 13,
-        "id2": 27,
+        "id1": "eminentdomain",
+        "id2": "lifeleech",
         "interaction": "Turrets captured by Amon have Life Leech."
     },
     {
-        "id1": 13,
-        "id2": 28,
+        "id1": "eminentdomain",
+        "id2": "longrange",
         "interaction": "Structures captured by Amon get the Long Range buff."
     },
     {
-        "id1": 13,
-        "id2": 39,
+        "id1": "eminentdomain",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 13,
-        "id2": 41,
+        "id1": "eminentdomain",
+        "id2": "polarity",
         "interaction": "Structures captured by Amon get Polarity."
     },
     {
-        "id1": 13,
-        "id2": 43,
+        "id1": "eminentdomain",
+        "id2": "propagators",
         "interaction": "Structures hit by Propagators change to a Propagator and do not get converted. Propagators spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 13,
-        "id2": 54,
+        "id1": "eminentdomain",
+        "id2": "transmutation",
         "interaction": "The attack that kills a player's structure will not cause the enemy unit to Transmute."
     },
     {
-        "id1": 13,
-        "id2": 55,
+        "id1": "eminentdomain",
+        "id2": "trickortreat",
         "interaction": "Civilians spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 13,
-        "id2": 56,
+        "id1": "eminentdomain",
+        "id2": "turkeyshoot",
         "interaction": "Structures destroyed by Turkeys will be converted."
     },
     {
-        "id1": 13,
-        "id2": 59,
+        "id1": "eminentdomain",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 13,
-        "id2": 63,
+        "id1": "eminentdomain",
+        "id2": "boombots",
         "interaction": "Boom Bots spawn out of structures converted by Eminent Domain."
     },
     {
-        "id1": 14,
-        "id2": 18,
+        "id1": "evasivemaneuvers",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange get the Evasive Manuevers buff."
     },
     {
-        "id1": 14,
-        "id2": 21,
+        "id1": "evasivemaneuvers",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes do not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 23,
+        "id1": "evasivemaneuvers",
+        "id2": "justdie",
         "interaction": "Respawned units get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 33,
+        "id1": "evasivemaneuvers",
+        "id2": "minesweeper",
         "interaction": "Mines do not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 34,
+        "id1": "evasivemaneuvers",
+        "id2": "missilecommand",
         "interaction": "Missiles do not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 39,
+        "id1": "evasivemaneuvers",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 41,
+        "id1": "evasivemaneuvers",
+        "id2": "polarity",
         "interaction": "Damage blocked by Polarity still triggers Evasive Maneuvers."
     },
     {
-        "id1": 14,
-        "id2": 43,
+        "id1": "evasivemaneuvers",
+        "id2": "propagators",
         "interaction": "Propagators do not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 54,
+        "id1": "evasivemaneuvers",
+        "id2": "transmutation",
         "interaction": "Transmuted units get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 55,
+        "id1": "evasivemaneuvers",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 56,
+        "id1": "evasivemaneuvers",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not get the Evasive Maneuvers buff. Angry Turkeys get the Evasive Maneuvers buff. The Turking does not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 59,
+        "id1": "evasivemaneuvers",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 60,
+        "id1": "evasivemaneuvers",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts get the Evasive Maneuvers buff."
     },
     {
-        "id1": 14,
-        "id2": 61,
+        "id1": "evasivemaneuvers",
+        "id2": "walkinginfested",
         "interaction": "Infested get the Evasive Maneuvers buff."
     },
     {
-        "id1": 15,
-        "id2": 18,
+        "id1": "fatalattraction",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 21,
+        "id1": "fatalattraction",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 23,
+        "id1": "fatalattraction",
+        "id2": "justdie",
         "interaction": "Units do not trigger Fatal Attraction when taking fatal damage and respawning."
     },
     {
-        "id1": 15,
-        "id2": 24,
+        "id1": "fatalattraction",
+        "id2": "killbots",
         "interaction": "Kill Bots trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 30,
+        "id1": "fatalattraction",
+        "id2": "magnificent",
         "interaction": "Mag-mines trigger Fatal Attraction when they detonate."
     },
     {
-        "id1": 15,
-        "id2": 32,
+        "id1": "fatalattraction",
+        "id2": "mineralshields",
         "interaction": "Mineral Shields trigger Fatal Attraction when destroyed or when they expire.\r\n."
     },
     {
-        "id1": 15,
-        "id2": 33,
+        "id1": "fatalattraction",
+        "id2": "minesweeper",
         "interaction": "Mines trigger Fatal Attraction when they are destroyed."
     },
     {
-        "id1": 15,
-        "id2": 34,
+        "id1": "fatalattraction",
+        "id2": "missilecommand",
         "interaction": "Missiles do not trigger Fatal Attraction when destroyed."
     },
     {
-        "id1": 15,
-        "id2": 36,
+        "id1": "fatalattraction",
+        "id2": "mutuallyassureddestruction",
         "interaction": "Hybrids will only trigger Mutually Assured Destruction"
     },
     {
-        "id1": 15,
-        "id2": 39,
+        "id1": "fatalattraction",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 43,
+        "id1": "fatalattraction",
+        "id2": "propagators",
         "interaction": "Propagators trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 54,
+        "id1": "fatalattraction",
+        "id2": "transmutation",
         "interaction": "Transmuted units trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 55,
+        "id1": "fatalattraction",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians  trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 56,
+        "id1": "fatalattraction",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 59,
+        "id1": "fatalattraction",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 60,
+        "id1": "fatalattraction",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 61,
+        "id1": "fatalattraction",
+        "id2": "walkinginfested",
         "interaction": "Infested trigger Fatal Attraction when they die."
     },
     {
-        "id1": 15,
-        "id2": 63,
+        "id1": "fatalattraction",
+        "id2": "boombots",
         "interaction": "Boom Bots trigger Fatal Attraction when they die."
     },
     {
-        "id1": 16,
-        "id2": 17,
+        "id1": "fear",
+        "id2": "fireworks",
         "interaction": "Fireworks can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 18,
+        "id1": "fear",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 19,
+        "id1": "fear",
+        "id2": "goingnuclear",
         "interaction": "Nukes can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 21,
+        "id1": "fear",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 23,
+        "id1": "fear",
+        "id2": "justdie",
         "interaction": "Respawned units can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 24,
+        "id1": "fear",
+        "id2": "killbots",
         "interaction": "Kill Bots can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 25,
+        "id1": "fear",
+        "id2": "laserdrill",
         "interaction": "Laser Drill can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 26,
+        "id1": "fear",
+        "id2": "lavaburst",
         "interaction": "Lava Burst can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 30,
+        "id1": "fear",
+        "id2": "magnificent",
         "interaction": "Mines can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 33,
+        "id1": "fear",
+        "id2": "minesweeper",
         "interaction": "Mines can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 36,
+        "id1": "fear",
+        "id2": "mutuallyassureddestruction",
         "interaction": "Hybrid Nukes can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 38,
+        "id1": "fear",
+        "id2": "orbitalstrike",
         "interaction": "Orbital Strikes can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 39,
+        "id1": "fear",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 40,
+        "id1": "fear",
+        "id2": "photonoverload",
         "interaction": "Photon Overload can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 44,
+        "id1": "fear",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 46,
+        "id1": "fear",
+        "id2": "scorchedearth",
         "interaction": "Scorched Earth can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 47,
+        "id1": "fear",
+        "id2": "selfdestruction",
         "interaction": "Self Destruction can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 54,
+        "id1": "fear",
+        "id2": "transmutation",
         "interaction": "Transmuted units can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 55,
+        "id1": "fear",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 56,
+        "id1": "fear",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 57,
+        "id1": "fear",
+        "id2": "twister",
         "interaction": "Twisters can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 59,
+        "id1": "fear",
+        "id2": "voidreanimators",
         "interaction": "Resurrected units can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 60,
+        "id1": "fear",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 61,
+        "id1": "fear",
+        "id2": "walkinginfested",
         "interaction": "Infested can apply the Fear effect."
     },
     {
-        "id1": 16,
-        "id2": 63,
+        "id1": "fear",
+        "id2": "boombots",
         "interaction": "Boom Bots do not apply the Fear effect."
     },
     {
-        "id1": 17,
-        "id2": 18,
+        "id1": "fireworks",
+        "id2": "giftexchange",
         "interaction": "Units spawned from Gift Exchange launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 21,
+        "id1": "fireworks",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes do not launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 24,
+        "id1": "fireworks",
+        "id2": "killbots",
         "interaction": "Kill Bots launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 30,
+        "id1": "fireworks",
+        "id2": "magnificent",
         "interaction": "Mines do not launch Fireworks when they explode."
     },
     {
-        "id1": 17,
-        "id2": 33,
+        "id1": "fireworks",
+        "id2": "minesweeper",
         "interaction": "Mines do not launch Fireworks when they are destroyed."
     },
     {
-        "id1": 17,
-        "id2": 34,
+        "id1": "fireworks",
+        "id2": "missilecommand",
         "interaction": "Missiles do not launch Fireworks when they are destroyed."
     },
     {
-        "id1": 17,
-        "id2": 39,
+        "id1": "fireworks",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 43,
+        "id1": "fireworks",
+        "id2": "propagators",
         "interaction": "Propagators do not launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 55,
+        "id1": "fireworks",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 56,
+        "id1": "fireworks",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not launch Fireworks when they die. The Turking launches Fireworks when it dies."
     },
     {
-        "id1": 17,
-        "id2": 59,
+        "id1": "fireworks",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 60,
+        "id1": "fireworks",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 61,
+        "id1": "fireworks",
+        "id2": "walkinginfested",
         "interaction": "Infested do not launch Fireworks when they die."
     },
     {
-        "id1": 17,
-        "id2": 63,
+        "id1": "fireworks",
+        "id2": "boombots",
         "interaction": "Boom Bots launch Fireworks when they die."
     },
     {
-        "id1": 18,
-        "id2": 20,
+        "id1": "giftexchange",
+        "id2": "hardenedwill",
         "interaction": "Units spawned from Gift Exchange can cause Hardened Will to activate. Hybrids and Kill Bots spawned from Gift Exchange can get the Hardened Will buff."
     },
     {
-        "id1": 18,
-        "id2": 21,
+        "id1": "giftexchange",
+        "id2": "heroesfromthestorm",
         "interaction": "Gift spawns do not spawn an Amon Heroes with the capturing attack force. Amon Heroes can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 22,
+        "id1": "giftexchange",
+        "id2": "inspiration",
         "interaction": "Units spawned from Gift Exchange can get the Inspiration buff. Hybrids and Kill Bots spawned from Gift Exchange can provide the Inspiration buff."
     },
     {
-        "id1": 18,
-        "id2": 23,
+        "id1": "giftexchange",
+        "id2": "justdie",
         "interaction": "Units spawned from Gift Exchange respawn when they die."
     },
     {
-        "id1": 18,
-        "id2": 24,
+        "id1": "giftexchange",
+        "id2": "killbots",
         "interaction": "Kill Bots can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 25,
+        "id1": "giftexchange",
+        "id2": "laserdrill",
         "interaction": "Gifts do not provide vision for the Laser Drill."
     },
     {
-        "id1": 18,
-        "id2": 26,
+        "id1": "giftexchange",
+        "id2": "lavaburst",
         "interaction": "Lava Bursts cannot capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 27,
+        "id1": "giftexchange",
+        "id2": "lifeleech",
         "interaction": "Units spawned from Gift Exchange have Life Leech."
     },
     {
-        "id1": 18,
-        "id2": 28,
+        "id1": "giftexchange",
+        "id2": "longrange",
         "interaction": "Units spawned from Gift Exchange get the Long Range buff."
     },
     {
-        "id1": 18,
-        "id2": 30,
+        "id1": "giftexchange",
+        "id2": "magnificent",
         "interaction": "Mag-mines can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 33,
+        "id1": "giftexchange",
+        "id2": "minesweeper",
         "interaction": "Mines can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 34,
+        "id1": "giftexchange",
+        "id2": "missilecommand",
         "interaction": "Missiles can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 35,
+        "id1": "giftexchange",
+        "id2": "momentofsilence",
         "interaction": "Hybrids spawned from Gift Exchange trigger Moment of Silence when they die."
     },
     {
-        "id1": 18,
-        "id2": 36,
+        "id1": "giftexchange",
+        "id2": "mutuallyassureddestruction",
         "interaction": "Hybrids spawned from Gift Exchange detonate Hybrid Nukes when they die."
     },
     {
-        "id1": 18,
-        "id2": 37,
+        "id1": "giftexchange",
+        "id2": "naughtylist",
         "interaction": "Units spawned from Gift Exchange kills increase the Naughty List count."
     },
     {
-        "id1": 18,
-        "id2": 39,
+        "id1": "giftexchange",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 41,
+        "id1": "giftexchange",
+        "id2": "polarity",
         "interaction": "Units spawned from Gift Exchange all have Polarity applied to them."
     },
     {
-        "id1": 18,
-        "id2": 42,
+        "id1": "giftexchange",
+        "id2": "poweroverwhelming",
         "interaction": "Units spawned from Gift Exchange can cast abilities."
     },
     {
-        "id1": 18,
-        "id2": 43,
+        "id1": "giftexchange",
+        "id2": "propagators",
         "interaction": "Propagators can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 44,
+        "id1": "giftexchange",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 46,
+        "id1": "giftexchange",
+        "id2": "scorchedearth",
         "interaction": "Units spawned from Gift Exchange set the ground on fire when they die."
     },
     {
-        "id1": 18,
-        "id2": 47,
+        "id1": "giftexchange",
+        "id2": "selfdestruction",
         "interaction": "Units spawned from Gift Exchange create an explosion when they die."
     },
     {
-        "id1": 18,
-        "id2": 51,
+        "id1": "giftexchange",
+        "id2": "speedfreaks",
         "interaction": "Units spawned from Gift Exchange move faster with Speed Freaks."
     },
     {
-        "id1": 18,
-        "id2": 52,
+        "id1": "giftexchange",
+        "id2": "temporalfield",
         "interaction": "Temporal Fields cannot capture gifts. Units caught in a Temporal Field can still capture Gifts."
     },
     {
-        "id1": 18,
-        "id2": 53,
+        "id1": "giftexchange",
+        "id2": "timewarp",
         "interaction": "Time Warps cannot capture gifts. Units caught in a Time Warp can still capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 54,
+        "id1": "giftexchange",
+        "id2": "transmutation",
         "interaction": "Units spawned from Gift Exchange can Transmute."
     },
     {
-        "id1": 18,
-        "id2": 56,
+        "id1": "giftexchange",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys cannot capture gifts. Angry Turkeys can capture gifts. The Turking can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 57,
+        "id1": "giftexchange",
+        "id2": "twister",
         "interaction": "Twisters can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 59,
+        "id1": "giftexchange",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can capture gifts. Void Reanimators can resurrect units spawned from Gift Exchange. Void Reanimators do not resurrect Kill Bots."
     },
     {
-        "id1": 18,
-        "id2": 60,
+        "id1": "giftexchange",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can capture gifts."
     },
     {
-        "id1": 18,
-        "id2": 61,
+        "id1": "giftexchange",
+        "id2": "walkinginfested",
         "interaction": "Infested can capture gifts. Units spawned from Gift Exchange spawn Infested when they die."
     },
     {
-        "id1": 18,
-        "id2": 62,
+        "id1": "giftexchange",
+        "id2": "wemoveunseen",
         "interaction": "Units spawned from Gift Exchange are cloaked."
     },
     {
-        "id1": 18,
-        "id2": 63,
+        "id1": "giftexchange",
+        "id2": "boombots",
         "interaction": "Boom Bots do not capture gifts."
     },
     {
-        "id1": 19,
-        "id2": 25,
+        "id1": "goingnuclear",
+        "id2": "laserdrill",
         "interaction": "The Laser Drill has vision of the area for a short time after the nuke hits."
     },
     {
-        "id1": 20,
-        "id2": 21,
+        "id1": "hardenedwill",
+        "id2": "heroesfromthestorm",
         "interaction": "Amon Heroes can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 24,
+        "id1": "hardenedwill",
+        "id2": "killbots",
         "interaction": "Kill Bots can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 30,
+        "id1": "hardenedwill",
+        "id2": "magnificent",
         "interaction": "Mag-mines do not cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 33,
+        "id1": "hardenedwill",
+        "id2": "minesweeper",
         "interaction": "Mines cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 34,
+        "id1": "hardenedwill",
+        "id2": "missilecommand",
         "interaction": "Missiles cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 39,
+        "id1": "hardenedwill",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 43,
+        "id1": "hardenedwill",
+        "id2": "propagators",
         "interaction": "Propagators can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 44,
+        "id1": "hardenedwill",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beam does not cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 54,
+        "id1": "hardenedwill",
+        "id2": "transmutation",
         "interaction": "Transmuted units cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 55,
+        "id1": "hardenedwill",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians can cause Hardened Will to activate. Hybrids spawned from Civilians can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 56,
+        "id1": "hardenedwill",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not cause Hardened Will to activate. Angry Turkeys cause Hardened Will to activate. The Turking can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 60,
+        "id1": "hardenedwill",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts cause Hardened Will to activate. Hybrids spawned from Void Rifts can get the Hardened Will buff."
     },
     {
-        "id1": 20,
-        "id2": 61,
+        "id1": "hardenedwill",
+        "id2": "walkinginfested",
         "interaction": "Infested cause Hardened Will to activate."
     },
     {
-        "id1": 20,
-        "id2": 63,
+        "id1": "hardenedwill",
+        "id2": "boombots",
         "interaction": "Boom Bots do not get the Hardened Will buff."
     },
     {
-        "id1": 21,
-        "id2": 22,
+        "id1": "heroesfromthestorm",
+        "id2": "inspiration",
         "interaction": "Amon Heroes can provide the Inspiration buff."
     },
     {
-        "id1": 21,
-        "id2": 23,
+        "id1": "heroesfromthestorm",
+        "id2": "justdie",
         "interaction": "Amon Heroes respawn when they die."
     },
     {
-        "id1": 21,
-        "id2": 27,
+        "id1": "heroesfromthestorm",
+        "id2": "lifeleech",
         "interaction": "Amon Heroes have Life Leech."
     },
     {
-        "id1": 21,
-        "id2": 28,
+        "id1": "heroesfromthestorm",
+        "id2": "longrange",
         "interaction": "Amon Heroes do not get the Long Range buff."
     },
     {
-        "id1": 21,
-        "id2": 35,
+        "id1": "heroesfromthestorm",
+        "id2": "momentofsilence",
         "interaction": "Amon Heroes trigger Moment of Silence when they die."
     },
     {
-        "id1": 21,
-        "id2": 37,
+        "id1": "heroesfromthestorm",
+        "id2": "naughtylist",
         "interaction": "Amon Hero kills increase the Naughty List count."
     },
     {
-        "id1": 21,
-        "id2": 40,
+        "id1": "heroesfromthestorm",
+        "id2": "photonoverload",
         "interaction": "Amon's Karax's spawned structures will have Photon Overload applied when damaged."
     },
     {
-        "id1": 21,
-        "id2": 41,
+        "id1": "heroesfromthestorm",
+        "id2": "polarity",
         "interaction": "Amon Heroes all have Polarity applied to them."
     },
     {
-        "id1": 21,
-        "id2": 42,
+        "id1": "heroesfromthestorm",
+        "id2": "poweroverwhelming",
         "interaction": "Amon Heroes can cast abilities other than the ones they already have."
     },
     {
-        "id1": 21,
-        "id2": 46,
+        "id1": "heroesfromthestorm",
+        "id2": "scorchedearth",
         "interaction": "Amon Heroes set the ground on fire when they die."
     },
     {
-        "id1": 21,
-        "id2": 47,
+        "id1": "heroesfromthestorm",
+        "id2": "selfdestruction",
         "interaction": "Amon Heroes create an explosion when they die."
     },
     {
-        "id1": 21,
-        "id2": 51,
+        "id1": "heroesfromthestorm",
+        "id2": "speedfreaks",
         "interaction": "Amon Heroes move faster with Speed Freaks."
     },
     {
-        "id1": 21,
-        "id2": 54,
+        "id1": "heroesfromthestorm",
+        "id2": "transmutation",
         "interaction": "Amon Heroes do not Transmute after killing a unit."
     },
     {
-        "id1": 21,
-        "id2": 59,
+        "id1": "heroesfromthestorm",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not resurrect Amon Heroes."
     },
     {
-        "id1": 21,
-        "id2": 61,
+        "id1": "heroesfromthestorm",
+        "id2": "walkinginfested",
         "interaction": "Amon Heroes spawn Infested when they die."
     },
     {
-        "id1": 21,
-        "id2": 62,
+        "id1": "heroesfromthestorm",
+        "id2": "wemoveunseen",
         "interaction": "Amon Heroes are cloaked."
     },
     {
-        "id1": 22,
-        "id2": 24,
+        "id1": "inspiration",
+        "id2": "killbots",
         "interaction": "Kill Bots can provide the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 39,
+        "id1": "inspiration",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations can get the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 43,
+        "id1": "inspiration",
+        "id2": "propagators",
         "interaction": "Propagators can provide the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 54,
+        "id1": "inspiration",
+        "id2": "transmutation",
         "interaction": "Transmuted units can get the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 55,
+        "id1": "inspiration",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians can get the Inspiration buff. Hybrids spawned from Civilians can provide the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 56,
+        "id1": "inspiration",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not get the Inspiration buff. Angry Turkeys get the Inspiration buff. The Turking can provide the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 59,
+        "id1": "inspiration",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can get the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 60,
+        "id1": "inspiration",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can get the Inspiration buff. Hybrids spawned from Void Rifts can provide the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 61,
+        "id1": "inspiration",
+        "id2": "walkinginfested",
         "interaction": "Infested can get the Inspiration buff."
     },
     {
-        "id1": 22,
-        "id2": 63,
+        "id1": "inspiration",
+        "id2": "boombots",
         "interaction": "Boom Bots do not provide the Inspiration buff."
     },
     {
-        "id1": 23,
-        "id2": 24,
+        "id1": "justdie",
+        "id2": "killbots",
         "interaction": "Kill Bots do not respawn when they self-destruct. They will respawn if killed by Abathur's Toxic Nests."
     },
     {
-        "id1": 23,
-        "id2": 27,
+        "id1": "justdie",
+        "id2": "lifeleech",
         "interaction": "Respawned units have Life Leech."
     },
     {
-        "id1": 23,
-        "id2": 30,
+        "id1": "justdie",
+        "id2": "magnificent",
         "interaction": "Mag-mines do not respawn when they explode."
     },
     {
-        "id1": 23,
-        "id2": 33,
+        "id1": "justdie",
+        "id2": "minesweeper",
         "interaction": "Mines respawn when they are destroyed."
     },
     {
-        "id1": 23,
-        "id2": 34,
+        "id1": "justdie",
+        "id2": "missilecommand",
         "interaction": "Missiles respawn when destroyed."
     },
     {
-        "id1": 23,
-        "id2": 35,
+        "id1": "justdie",
+        "id2": "momentofsilence",
         "interaction": "Units do not trigger Moment of Silence when taking fatal damage and respawning."
     },
     {
-        "id1": 23,
-        "id2": 36,
+        "id1": "justdie",
+        "id2": "mutuallyassureddestruction",
         "interaction": "Hybrids do not detonate Hybrid Nukes when taking fatal damage and respawning."
     },
     {
-        "id1": 23,
-        "id2": 37,
+        "id1": "justdie",
+        "id2": "naughtylist",
         "interaction": "Units do not increase the Naughty List count when taking fatal damage and respawning."
     },
     {
-        "id1": 23,
-        "id2": 39,
+        "id1": "justdie",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations respawn when they die."
     },
     {
-        "id1": 23,
-        "id2": 41,
+        "id1": "justdie",
+        "id2": "polarity",
         "interaction": "Polarity reverses after a unit respawns."
     },
     {
-        "id1": 23,
-        "id2": 43,
+        "id1": "justdie",
+        "id2": "propagators",
         "interaction": "Propagators respawn when they die. When a Propagator Propagates a unit, the new Propagator will have the Just Die! buff applied to it too and will need to be killed twice."
     },
     {
-        "id1": 23,
-        "id2": 46,
+        "id1": "justdie",
+        "id2": "scorchedearth",
         "interaction": "Units do not set the ground of fire when taking fatal damage and respawning."
     },
     {
-        "id1": 23,
-        "id2": 47,
+        "id1": "justdie",
+        "id2": "selfdestruction",
         "interaction": "Units do set the ground on fire when taking fatal damage and respawning."
     },
     {
-        "id1": 23,
-        "id2": 51,
+        "id1": "justdie",
+        "id2": "speedfreaks",
         "interaction": "Respawned units keep moving faster with Speed Freaks."
     },
     {
-        "id1": 23,
-        "id2": 54,
+        "id1": "justdie",
+        "id2": "transmutation",
         "interaction": "Transmutated units have their Just Die stacks reset, allowing them to respawn again."
     },
     {
-        "id1": 23,
-        "id2": 55,
+        "id1": "justdie",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians respawn when they die."
     },
     {
-        "id1": 23,
-        "id2": 56,
+        "id1": "justdie",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not respawn when they die. The Turking respawns when it dies."
     },
     {
-        "id1": 23,
-        "id2": 59,
+        "id1": "justdie",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators respawn when they die. Resurrected units respawn when they die."
     },
     {
-        "id1": 23,
-        "id2": 60,
+        "id1": "justdie",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts respawn when they die."
     },
     {
-        "id1": 23,
-        "id2": 61,
+        "id1": "justdie",
+        "id2": "walkinginfested",
         "interaction": "Infested respawn when they die."
     },
     {
-        "id1": 23,
-        "id2": 62,
+        "id1": "justdie",
+        "id2": "wemoveunseen",
         "interaction": "Respawned units are cloaked."
     },
     {
-        "id1": 23,
-        "id2": 63,
+        "id1": "justdie",
+        "id2": "boombots",
         "interaction": "Boom Bots do not respawn when they self-destruct."
     },
     {
-        "id1": 24,
-        "id2": 25,
+        "id1": "killbots",
+        "id2": "laserdrill",
         "interaction": "Kill Bots provide vision for the Laser Drill.\r\nKill Bots do not spawn from the Laser Drill."
     },
     {
-        "id1": 24,
-        "id2": 28,
+        "id1": "killbots",
+        "id2": "longrange",
         "interaction": "Kill Bots get the Long Range buff."
     },
     {
-        "id1": 24,
-        "id2": 35,
+        "id1": "killbots",
+        "id2": "momentofsilence",
         "interaction": "Kill Bots trigger Moment of Silence when they die."
     },
     {
-        "id1": 24,
-        "id2": 42,
+        "id1": "killbots",
+        "id2": "poweroverwhelming",
         "interaction": "Kill Bots can cast abilities. Kill bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
-        "id1": 24,
-        "id2": 46,
+        "id1": "killbots",
+        "id2": "scorchedearth",
         "interaction": "Kill Bots set the ground on fire when they die."
     },
     {
-        "id1": 24,
-        "id2": 47,
+        "id1": "killbots",
+        "id2": "selfdestruction",
         "interaction": "Kill Bots create an explosion when they die."
     },
     {
-        "id1": 24,
-        "id2": 51,
+        "id1": "killbots",
+        "id2": "speedfreaks",
         "interaction": "Kill Bots move faster with Speed Freaks."
     },
     {
-        "id1": 24,
-        "id2": 54,
+        "id1": "killbots",
+        "id2": "transmutation",
         "interaction": "Kill Bots do not Transmute when dealing damage or killing units."
     },
     {
-        "id1": 24,
-        "id2": 59,
+        "id1": "killbots",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not resurrect Kill Bots."
     },
     {
-        "id1": 24,
-        "id2": 60,
+        "id1": "killbots",
+        "id2": "voidrifts",
         "interaction": "Kill Bots do not spawn from Void Rifts."
     },
     {
-        "id1": 24,
-        "id2": 61,
+        "id1": "killbots",
+        "id2": "walkinginfested",
         "interaction": "Kill Bots spawn Infested when they die."
     },
     {
-        "id1": 24,
-        "id2": 62,
+        "id1": "killbots",
+        "id2": "wemoveunseen",
         "interaction": "Kill Bots are cloaked."
     },
     {
-        "id1": 25,
-        "id2": 26,
+        "id1": "laserdrill",
+        "id2": "lavaburst",
         "interaction": "Lava Bursts do not provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 27,
+        "id1": "laserdrill",
+        "id2": "lifeleech",
         "interaction": "Laser Drill has Life Leech."
     },
     {
-        "id1": 25,
-        "id2": 30,
+        "id1": "laserdrill",
+        "id2": "magnificent",
         "interaction": "Mag-mines provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 32,
+        "id1": "laserdrill",
+        "id2": "mineralshields",
         "interaction": "Mineral Shields provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 33,
+        "id1": "laserdrill",
+        "id2": "minesweeper",
         "interaction": "Mines provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 34,
+        "id1": "laserdrill",
+        "id2": "missilecommand",
         "interaction": "Missiles do not provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 39,
+        "id1": "laserdrill",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations provide vision for the Laser Drill.\r\nInfested and Aberrations do not spawn from the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 40,
+        "id1": "laserdrill",
+        "id2": "photonoverload",
         "interaction": "The Laser Drill does not get Photon Overcharge when damaged."
     },
     {
-        "id1": 25,
-        "id2": 41,
+        "id1": "laserdrill",
+        "id2": "polarity",
         "interaction": "Polarity of the Laser Drill remains fixed, even when the drill respawns after being destroyed."
     },
     {
-        "id1": 25,
-        "id2": 43,
+        "id1": "laserdrill",
+        "id2": "propagators",
         "interaction": "Propagators provide vision for the Laser Drill. Propagators do not spawn from the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 44,
+        "id1": "laserdrill",
+        "id2": "purifierbeam",
         "interaction": "Purifier Beams do not provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 52,
+        "id1": "laserdrill",
+        "id2": "temporalfield",
         "interaction": "The area inside a Temporal Field provides vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 53,
+        "id1": "laserdrill",
+        "id2": "timewarp",
         "interaction": "Time Warps do not provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 54,
+        "id1": "laserdrill",
+        "id2": "transmutation",
         "interaction": "Transmuted units provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 55,
+        "id1": "laserdrill",
+        "id2": "trickortreat",
         "interaction": "The Candy Bowl provides vision for the Laser Drill. Units spawned from Civilians provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 56,
+        "id1": "laserdrill",
+        "id2": "turkeyshoot",
         "interaction": "Normal Turkeys do not provide vision for the Laser Drill. Angry Turkeys provide vision for the Laser Drill. The Turking provides vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 57,
+        "id1": "laserdrill",
+        "id2": "twister",
         "interaction": "Twisters do not provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 59,
+        "id1": "laserdrill",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators provide vision for the Laser Drill. Void Reanimators do not spawn from the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 60,
+        "id1": "laserdrill",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 61,
+        "id1": "laserdrill",
+        "id2": "walkinginfested",
         "interaction": "Infested provide vision for the Laser Drill."
     },
     {
-        "id1": 25,
-        "id2": 63,
+        "id1": "laserdrill",
+        "id2": "boombots",
         "interaction": "Boom Bots provide vision for the Laser Drill.\r\nBoom Bots do not spawn from the Laser Drill."
     },
     {
-        "id1": 26,
-        "id2": 62,
+        "id1": "lavaburst",
+        "id2": "wemoveunseen",
         "interaction": "Lava Bursts are not cloaked."
     },
     {
-        "id1": 27,
-        "id2": 39,
+        "id1": "lifeleech",
+        "id2": "outbreak",
         "interaction": "Infested and Aberrations have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 54,
+        "id1": "lifeleech",
+        "id2": "transmutation",
         "interaction": "Transmuted units have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 55,
+        "id1": "lifeleech",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 56,
+        "id1": "lifeleech",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 59,
+        "id1": "lifeleech",
+        "id2": "voidreanimators",
         "interaction": "Resurrected units have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 60,
+        "id1": "lifeleech",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts have Life Leech."
     },
     {
-        "id1": 27,
-        "id2": 61,
+        "id1": "lifeleech",
+        "id2": "walkinginfested",
         "interaction": "Infested have Life Leech."
     },
     {
-        "id1": 28,
-        "id2": 30,
+        "id1": "longrange",
+        "id2": "magnificent",
         "interaction": "Mag-mines do not get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 33,
+        "id1": "longrange",
+        "id2": "minesweeper",
         "interaction": "Mines do not get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 39,
+        "id1": "longrange",
+        "id2": "outbreak",
         "interaction": "Infested Marines get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 40,
+        "id1": "longrange",
+        "id2": "photonoverload",
         "interaction": "Photon Overload gets increased range with Long Range."
     },
     {
-        "id1": 28,
-        "id2": 42,
+        "id1": "longrange",
+        "id2": "poweroverwhelming",
         "interaction": "Ranges of spells does not increase with Long Range."
     },
     {
-        "id1": 28,
-        "id2": 43,
+        "id1": "longrange",
+        "id2": "propagators",
         "interaction": "Propagators do not get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 55,
+        "id1": "longrange",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 56,
+        "id1": "longrange",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not get the Long Range buff."
     },
     {
-        "id1": 28,
-        "id2": 59,
+        "id1": "longrange",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not get increased Resurrection range."
     },
     {
-        "id1": 28,
-        "id2": 60,
+        "id1": "longrange",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts get the Long Range buff."
     },
     {
-        "id1": 30,
-        "id2": 42,
+        "id1": "magnificent",
+        "id2": "poweroverwhelming",
         "interaction": "Mag-mines cannot cast abilities."
     },
     {
-        "id1": 30,
-        "id2": 46,
+        "id1": "magnificent",
+        "id2": "scorchedearth",
         "interaction": "Mag-mines do not set the ground on fire when they explode."
     },
     {
-        "id1": 30,
-        "id2": 47,
+        "id1": "magnificent",
+        "id2": "selfdestruction",
         "interaction": "Mag-mines do not create an explosion when explode."
     },
     {
-        "id1": 30,
-        "id2": 51,
+        "id1": "magnificent",
+        "id2": "speedfreaks",
         "interaction": "Mag-mines do not move faster with Speed Freaks."
     },
     {
-        "id1": 30,
-        "id2": 54,
+        "id1": "magnificent",
+        "id2": "transmutation",
         "interaction": "Mag-mines do not Transmute after killing a unit."
     },
     {
-        "id1": 30,
-        "id2": 59,
+        "id1": "magnificent",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators do not resurrect Mag-mines."
     },
     {
-        "id1": 30,
-        "id2": 61,
+        "id1": "magnificent",
+        "id2": "walkinginfested",
         "interaction": "Mag-mines do not spawn Infested when they detonate."
     },
     {
-        "id1": 30,
-        "id2": 62,
+        "id1": "magnificent",
+        "id2": "wemoveunseen",
         "interaction": "Mag-mines are cloaked."
     },
     {
-        "id1": 32,
-        "id2": 37,
+        "id1": "mineralshields",
+        "id2": "naughtylist",
         "interaction": "Mineral Shield kills increase the Naughty List count."
     },
     {
-        "id1": 32,
-        "id2": 40,
+        "id1": "mineralshields",
+        "id2": "photonoverload",
         "interaction": "Mineral Shields will have Photon Overload applied when damaged."
     },
     {
-        "id1": 32,
-        "id2": 41,
+        "id1": "mineralshields",
+        "id2": "polarity",
         "interaction": "Mineral Shields all have Polarity applied to them."
     },
     {
-        "id1": 33,
-        "id2": 37,
+        "id1": "minesweeper",
+        "id2": "naughtylist",
         "interaction": "Mine kills increase the Naughty List count."
     },
     {
-        "id1": 33,
-        "id2": 41,
+        "id1": "minesweeper",
+        "id2": "polarity",
         "interaction": "Widow Mines and Spider Mines all have Polarity applied to them."
     },
     {
-        "id1": 33,
-        "id2": 42,
+        "id1": "minesweeper",
+        "id2": "poweroverwhelming",
         "interaction": "Widow mines can cast abilities. Spider mines cannot cast abilities."
     },
     {
-        "id1": 33,
-        "id2": 46,
+        "id1": "minesweeper",
+        "id2": "scorchedearth",
         "interaction": "Mines set the ground on fire when they die."
     },
     {
-        "id1": 33,
-        "id2": 47,
+        "id1": "minesweeper",
+        "id2": "selfdestruction",
         "interaction": "Mines set the ground on fire when they are destroyed."
     },
     {
-        "id1": 33,
-        "id2": 51,
+        "id1": "minesweeper",
+        "id2": "speedfreaks",
         "interaction": "Spider mines do not move faster with Speed Freaks."
     },
     {
-        "id1": 33,
-        "id2": 54,
+        "id1": "minesweeper",
+        "id2": "transmutation",
         "interaction": "Widow Mines Transmute after killing a unit."
     },
     {
-        "id1": 33,
-        "id2": 59,
+        "id1": "minesweeper",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators resurrect Widow Mines but not Spider Mines. Widow Mines will move towards player bases after resurrection."
     },
     {
-        "id1": 33,
-        "id2": 61,
+        "id1": "minesweeper",
+        "id2": "walkinginfested",
         "interaction": "Mines spawned Infested when they are destroyed."
     },
     {
-        "id1": 34,
-        "id2": 37,
+        "id1": "missilecommand",
+        "id2": "naughtylist",
         "interaction": "Missile kills do not increase the Naughty List count."
     },
     {
-        "id1": 34,
-        "id2": 41,
+        "id1": "missilecommand",
+        "id2": "polarity",
         "interaction": "Missiles have Polarity applied to them."
     },
     {
-        "id1": 34,
-        "id2": 42,
+        "id1": "missilecommand",
+        "id2": "poweroverwhelming",
         "interaction": "Point Defense Missiles can cast abilities."
     },
     {
-        "id1": 34,
-        "id2": 46,
+        "id1": "missilecommand",
+        "id2": "scorchedearth",
         "interaction": "Missiles set the ground on fire when they are destroyed."
     },
     {
-        "id1": 34,
-        "id2": 47,
+        "id1": "missilecommand",
+        "id2": "selfdestruction",
         "interaction": "Missiles create an explosion when destroyed."
     },
     {
-        "id1": 34,
-        "id2": 51,
+        "id1": "missilecommand",
+        "id2": "speedfreaks",
         "interaction": "Missiles do not move faster with Speed Freaks."
     },
     {
-        "id1": 34,
-        "id2": 59,
+        "id1": "missilecommand",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators cannot resurrect Missiles."
     },
     {
-        "id1": 34,
-        "id2": 61,
+        "id1": "missilecommand",
+        "id2": "walkinginfested",
         "interaction": "Missiles do not spawn Infested when they land on their target. Missiles spawn Infested when destroyed by players."
     },
     {
-        "id1": 34,
-        "id2": 62,
+        "id1": "missilecommand",
+        "id2": "wemoveunseen",
         "interaction": "Missiles are cloaked."
     },
     {
-        "id1": 35,
-        "id2": 43,
+        "id1": "momentofsilence",
+        "id2": "propagators",
         "interaction": "Propagators trigger Moment of Silence when they die."
     },
     {
-        "id1": 35,
-        "id2": 54,
+        "id1": "momentofsilence",
+        "id2": "transmutation",
         "interaction": "Transmuted units which are now Hybrids trigger Moment of Silence when they die."
     },
     {
-        "id1": 35,
-        "id2": 55,
+        "id1": "momentofsilence",
+        "id2": "trickortreat",
         "interaction": "Hybrids spawned from Civilians trigger Moment of Silence when they die."
     },
     {
-        "id1": 35,
-        "id2": 56,
+        "id1": "momentofsilence",
+        "id2": "turkeyshoot",
         "interaction": "The Turking triggers Moment of Silence when it dies."
     },
     {
-        "id1": 35,
-        "id2": 60,
+        "id1": "momentofsilence",
+        "id2": "voidrifts",
         "interaction": "Hybrids spawned from Void Rifts trigger Moment of Silence when they die."
     },
     {
-        "id1": 35,
-        "id2": 63,
+        "id1": "momentofsilence",
+        "id2": "boombots",
         "interaction": "Boom Bots do not trigger Moment of Silence when they die."
     },
     {
-        "id1": 36,
-        "id2": 55,
+        "id1": "mutuallyassureddestruction",
+        "id2": "trickortreat",
         "interaction": "Hybrids spawned from Civilians detonate Hybrid Nukes when they die."
     },
     {
-        "id1": 36,
-        "id2": 60,
+        "id1": "mutuallyassureddestruction",
+        "id2": "voidrifts",
         "interaction": "Hybrids spawned from Void Rifts detonate Hybrid Nukes when they die."
     },
     {
-        "id1": 37,
-        "id2": 39,
+        "id1": "naughtylist",
+        "id2": "outbreak",
         "interaction": "Infested and Aberration kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 43,
+        "id1": "naughtylist",
+        "id2": "propagators",
         "interaction": "Propagator kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 50,
+        "id1": "naughtylist",
+        "id2": "slimpickings",
         "interaction": "Turkey kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 55,
+        "id1": "naughtylist",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 56,
+        "id1": "naughtylist",
+        "id2": "turkeyshoot",
         "interaction": "Turkey kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 59,
+        "id1": "naughtylist",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimator kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 60,
+        "id1": "naughtylist",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts kills increase the Naughty List count."
     },
     {
-        "id1": 37,
-        "id2": 61,
+        "id1": "naughtylist",
+        "id2": "walkinginfested",
         "interaction": "Infested kills increase the Naughty List count."
     },
     {
-        "id1": 39,
-        "id2": 41,
+        "id1": "outbreak",
+        "id2": "polarity",
         "interaction": "Infested and Aberrations all have Polarity applied to them."
     },
     {
-        "id1": 39,
-        "id2": 42,
+        "id1": "outbreak",
+        "id2": "poweroverwhelming",
         "interaction": "Infested and Aberrations can cast abilities. Infested and Aberrations can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
-        "id1": 39,
-        "id2": 46,
+        "id1": "outbreak",
+        "id2": "scorchedearth",
         "interaction": "Infested and Aberrations set the ground on fire when they die."
     },
     {
-        "id1": 39,
-        "id2": 47,
+        "id1": "outbreak",
+        "id2": "selfdestruction",
         "interaction": "Infested and Aberrations create an explosion when they die."
     },
     {
-        "id1": 39,
-        "id2": 51,
+        "id1": "outbreak",
+        "id2": "speedfreaks",
         "interaction": "Infested and Aberrations move faster with Speed Freaks."
     },
     {
-        "id1": 39,
-        "id2": 54,
+        "id1": "outbreak",
+        "id2": "transmutation",
         "interaction": "Infested and Aberrations can transmute."
     },
     {
-        "id1": 39,
-        "id2": 59,
+        "id1": "outbreak",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can resurrect Infested and Aberrations."
     },
     {
-        "id1": 39,
-        "id2": 60,
+        "id1": "outbreak",
+        "id2": "voidrifts",
         "interaction": "Infested and Aberrations do not spawn from Void Rifts."
     },
     {
-        "id1": 39,
-        "id2": 61,
+        "id1": "outbreak",
+        "id2": "walkinginfested",
         "interaction": "Infested and Aberrations do not spawn other infested units when killed."
     },
     {
-        "id1": 39,
-        "id2": 62,
+        "id1": "outbreak",
+        "id2": "wemoveunseen",
         "interaction": "Infested and Aberrations are cloaked."
     },
     {
-        "id1": 40,
-        "id2": 42,
+        "id1": "photonoverload",
+        "id2": "poweroverwhelming",
         "interaction": "Point Defense Drones spawned from Power Overwhelming will gain Photon Overcharge when damaged."
     },
     {
-        "id1": 40,
-        "id2": 60,
+        "id1": "photonoverload",
+        "id2": "voidrifts",
         "interaction": "Void Rifts do not get Photon Overcharge when damaged. "
     },
     {
-        "id1": 41,
-        "id2": 43,
+        "id1": "polarity",
+        "id2": "propagators",
         "interaction": "Propagators that spawn around the map have Polarity applied to them. Propagators spawned from other Propagators do not have any polarity."
     },
     {
-        "id1": 41,
-        "id2": 54,
+        "id1": "polarity",
+        "id2": "transmutation",
         "interaction": "When units Transmute, they can switch Polarities."
     },
     {
-        "id1": 41,
-        "id2": 55,
+        "id1": "polarity",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians all have Polarity applied to them."
     },
     {
-        "id1": 41,
-        "id2": 56,
+        "id1": "polarity",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not have Polarity applied to them. The Turking has Polarity applied to it."
     },
     {
-        "id1": 41,
-        "id2": 59,
+        "id1": "polarity",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators all have Polarity applied to them. Resurrected units may change Polarity after resurrection."
     },
     {
-        "id1": 41,
-        "id2": 60,
+        "id1": "polarity",
+        "id2": "voidrifts",
         "interaction": "Void Rifts and units spawned from Void Rifts all have Polarity applied to them."
     },
     {
-        "id1": 41,
-        "id2": 61,
+        "id1": "polarity",
+        "id2": "walkinginfested",
         "interaction": "Infested all have Polarity applied to them."
     },
     {
-        "id1": 42,
-        "id2": 43,
+        "id1": "poweroverwhelming",
+        "id2": "propagators",
         "interaction": "Propagators can cast abilities. Propagators can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
-        "id1": 42,
-        "id2": 55,
+        "id1": "poweroverwhelming",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians  can cast abilities."
     },
     {
-        "id1": 42,
-        "id2": 56,
+        "id1": "poweroverwhelming",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys cannot cast abilities."
     },
     {
-        "id1": 42,
-        "id2": 59,
+        "id1": "poweroverwhelming",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can cast abilities. Void Reanimators can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
-        "id1": 42,
-        "id2": 60,
+        "id1": "poweroverwhelming",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can cast abilities."
     },
     {
-        "id1": 42,
-        "id2": 61,
+        "id1": "poweroverwhelming",
+        "id2": "walkinginfested",
         "interaction": "Infested can cast abilities."
     },
     {
-        "id1": 42,
-        "id2": 63,
+        "id1": "poweroverwhelming",
+        "id2": "boombots",
         "interaction": "Boom Bots can cast abilities. Boom Bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
     },
     {
-        "id1": 43,
-        "id2": 46,
+        "id1": "propagators",
+        "id2": "scorchedearth",
         "interaction": "Propagators set the ground on fire when they die."
     },
     {
-        "id1": 43,
-        "id2": 47,
+        "id1": "propagators",
+        "id2": "selfdestruction",
         "interaction": "Propagators create an explosion when they die."
     },
     {
-        "id1": 43,
-        "id2": 51,
+        "id1": "propagators",
+        "id2": "speedfreaks",
         "interaction": "Propagators move faster with Speed Freaks."
     },
     {
-        "id1": 43,
-        "id2": 54,
+        "id1": "propagators",
+        "id2": "transmutation",
         "interaction": "Propagators do not Transmute."
     },
     {
-        "id1": 43,
-        "id2": 59,
+        "id1": "propagators",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can resurrect Propagators. Propagators resurrected by Void Reanimators are not marked with an icon on the minimap."
     },
     {
-        "id1": 43,
-        "id2": 60,
+        "id1": "propagators",
+        "id2": "voidrifts",
         "interaction": "Propagators do not spawn from Void Rifts."
     },
     {
-        "id1": 43,
-        "id2": 61,
+        "id1": "propagators",
+        "id2": "walkinginfested",
         "interaction": "Propagators spawn Infested when they die."
     },
     {
-        "id1": 43,
-        "id2": 62,
+        "id1": "propagators",
+        "id2": "wemoveunseen",
         "interaction": "Propagators are cloaked."
     },
     {
-        "id1": 44,
-        "id2": 51,
+        "id1": "purifierbeam",
+        "id2": "speedfreaks",
         "interaction": "Purifier Beam does not move faster with Speed Freaks."
     },
     {
-        "id1": 44,
-        "id2": 62,
+        "id1": "purifierbeam",
+        "id2": "wemoveunseen",
         "interaction": "Purifier Beam is cloaked."
     },
     {
-        "id1": 46,
-        "id2": 55,
+        "id1": "scorchedearth",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians set the ground on fire when they die."
     },
     {
-        "id1": 46,
-        "id2": 56,
+        "id1": "scorchedearth",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys set the ground on fire when they die."
     },
     {
-        "id1": 46,
-        "id2": 59,
+        "id1": "scorchedearth",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators set the ground on fire when they die."
     },
     {
-        "id1": 46,
-        "id2": 60,
+        "id1": "scorchedearth",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts set the ground on fire when they die."
     },
     {
-        "id1": 46,
-        "id2": 61,
+        "id1": "scorchedearth",
+        "id2": "walkinginfested",
         "interaction": "Infested set the ground on fire when they die."
     },
     {
-        "id1": 46,
-        "id2": 63,
+        "id1": "scorchedearth",
+        "id2": "boombots",
         "interaction": "Boom Bots set the ground on fire when they die."
     },
     {
-        "id1": 47,
-        "id2": 55,
+        "id1": "selfdestruction",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians create an explosion when they die."
     },
     {
-        "id1": 47,
-        "id2": 56,
+        "id1": "selfdestruction",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not create an explosion when they die. Angry Turkeys create an explosion when they die. The Turking creates an explosion when it does."
     },
     {
-        "id1": 47,
-        "id2": 59,
+        "id1": "selfdestruction",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators create an explosion when they die."
     },
     {
-        "id1": 47,
-        "id2": 60,
+        "id1": "selfdestruction",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts  create an explosion when they die."
     },
     {
-        "id1": 47,
-        "id2": 61,
+        "id1": "selfdestruction",
+        "id2": "walkinginfested",
         "interaction": "Infested create an explosion when they die."
     },
     {
-        "id1": 47,
-        "id2": 63,
+        "id1": "selfdestruction",
+        "id2": "boombots",
         "interaction": "Boom Bots create an explosion when they die."
     },
     {
-        "id1": 51,
-        "id2": 54,
+        "id1": "speedfreaks",
+        "id2": "transmutation",
         "interaction": "Transmuted units move faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 55,
+        "id1": "speedfreaks",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians move faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 56,
+        "id1": "speedfreaks",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys do not move faster with Speed Freaks. The Turking moves faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 59,
+        "id1": "speedfreaks",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators move faster with Speed Freaks. Resurrected units move faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 60,
+        "id1": "speedfreaks",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts move faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 61,
+        "id1": "speedfreaks",
+        "id2": "walkinginfested",
         "interaction": "Infested units move faster with Speed Freaks."
     },
     {
-        "id1": 51,
-        "id2": 63,
+        "id1": "speedfreaks",
+        "id2": "boombots",
         "interaction": "Boom Bots move faster with Speed Freaks."
     },
     {
-        "id1": 52,
-        "id2": 62,
+        "id1": "temporalfield",
+        "id2": "wemoveunseen",
         "interaction": "Temporal Fields are not cloaked."
     },
     {
-        "id1": 53,
-        "id2": 62,
+        "id1": "timewarp",
+        "id2": "wemoveunseen",
         "interaction": "Time Warps are not cloaked."
     },
     {
-        "id1": 54,
-        "id2": 55,
+        "id1": "transmutation",
+        "id2": "trickortreat",
         "interaction": "Units spawned from Civilians can Transmute."
     },
     {
-        "id1": 54,
-        "id2": 56,
+        "id1": "transmutation",
+        "id2": "turkeyshoot",
         "interaction": "Turkeys can transmute when they deal damage or kill a unit. The Turking does not transmute."
     },
     {
-        "id1": 54,
-        "id2": 59,
+        "id1": "transmutation",
+        "id2": "voidreanimators",
         "interaction": "Resurrected units can Transmute."
     },
     {
-        "id1": 54,
-        "id2": 60,
+        "id1": "transmutation",
+        "id2": "voidrifts",
         "interaction": "Units spawned from Void Rifts can transmute."
     },
     {
-        "id1": 54,
-        "id2": 61,
+        "id1": "transmutation",
+        "id2": "walkinginfested",
         "interaction": "Infested can transmute. Newly-transmuted units spawn Infested when they die."
     },
     {
-        "id1": 54,
-        "id2": 62,
+        "id1": "transmutation",
+        "id2": "wemoveunseen",
         "interaction": "Transmuted units are cloaked."
     },
     {
-        "id1": 55,
-        "id2": 59,
+        "id1": "trickortreat",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can resurrect units spawned from Civilians."
     },
     {
-        "id1": 55,
-        "id2": 60,
+        "id1": "trickortreat",
+        "id2": "voidrifts",
         "interaction": "Civilians do not spawn from Void Rifts."
     },
     {
-        "id1": 55,
-        "id2": 61,
+        "id1": "trickortreat",
+        "id2": "walkinginfested",
         "interaction": "Units spawned from Civilians spawn Infested when they die."
     },
     {
-        "id1": 55,
-        "id2": 62,
+        "id1": "trickortreat",
+        "id2": "wemoveunseen",
         "interaction": "Units spawned from Civilians are cloaked."
     },
     {
-        "id1": 56,
-        "id2": 59,
+        "id1": "turkeyshoot",
+        "id2": "voidreanimators",
         "interaction": "Void Reanimators can resurrect Turkeys. Void Reanimators do not resurrect the Turking."
     },
     {
-        "id1": 56,
-        "id2": 61,
+        "id1": "turkeyshoot",
+        "id2": "walkinginfested",
         "interaction": "Turkeys do not spawn Infested when they die. Angry Turkeys spawn Infested when they die. The Turking does not spawn Infested when it dies."
     },
     {
-        "id1": 56,
-        "id2": 62,
+        "id1": "turkeyshoot",
+        "id2": "wemoveunseen",
         "interaction": "Turkeys are not cloaked. The Turking is cloaked."
     },
     {
-        "id1": 57,
-        "id2": 62,
+        "id1": "twister",
+        "id2": "wemoveunseen",
         "interaction": "Twisters are not cloaked."
     },
     {
-        "id1": 59,
-        "id2": 60,
+        "id1": "voidreanimators",
+        "id2": "voidrifts",
         "interaction": "Void Reanimators can resurrect units spawned from Void Rifts.\r\nVoid Reanimators do not spawn from Void Rifts."
     },
     {
-        "id1": 59,
-        "id2": 61,
+        "id1": "voidreanimators",
+        "id2": "walkinginfested",
         "interaction": "Void Reanimators can resurrect Infested."
     },
     {
-        "id1": 59,
-        "id2": 62,
+        "id1": "voidreanimators",
+        "id2": "wemoveunseen",
         "interaction": "Void Reanimators are cloaked."
     },
     {
-        "id1": 59,
-        "id2": 63,
+        "id1": "voidreanimators",
+        "id2": "boombots",
         "interaction": "Void Reanimators do not resurrect Boom Bots."
     },
     {
-        "id1": 60,
-        "id2": 61,
+        "id1": "voidrifts",
+        "id2": "walkinginfested",
         "interaction": "Units spawned from Void Rifts spawn Infested when they die."
     },
     {
-        "id1": 60,
-        "id2": 62,
+        "id1": "voidrifts",
+        "id2": "wemoveunseen",
         "interaction": "Units spawned from Void Rifts are cloaked."
     },
     {
-        "id1": 60,
-        "id2": 63,
+        "id1": "voidrifts",
+        "id2": "boombots",
         "interaction": "Boom Bots do not spawn from Void Rifts."
     },
     {
-        "id1": 61,
-        "id2": 62,
+        "id1": "walkinginfested",
+        "id2": "wemoveunseen",
         "interaction": "Infested are cloaked."
     },
     {
-        "id1": 61,
-        "id2": 63,
+        "id1": "walkinginfested",
+        "id2": "boombots",
         "interaction": "Boom Bots spawn Infested when they die."
     },
     {
-        "id1": 62,
-        "id2": 63,
+        "id1": "wemoveunseen",
+        "id2": "boombots",
         "interaction": "Boom Bots are cloaked, but their tags are still visible.\r\nCodes cannot be input without detection."
     }
 ]

--- a/html/resources/mutators.html
+++ b/html/resources/mutators.html
@@ -317,137 +317,140 @@ if (document.location.host === 'dev.starcraft2coop.com') {
         <form action="mutators.php" method="post">
         <p class="centerAlign">Mutator 1:</p>
         <select name="mut1" id="mut1">
-            <option value='0'>-</option><option value='1'>Afraid of the Dark</option>
-<option value='2'>Aggressive Deployment</option>
-<option value='3'>Alien Incubation</option>
-<option value='4'>Avenger</option>
-<option value='5'>Barrier</option>
-<option value='6'>Black Death</option>
-<option value='7'>Blizzard</option>
-<option value='63'>Boom Bots</option>
-<option value='8'>Chaos Studios</option>
-<option value='9'>Concussive Attacks</option>
-<option value='10'>Darkness</option>
-<option value='11'>Diffusion</option>
-<option value='12'>Double Edged</option>
-<option value='13'>Eminent Domain</option>
-<option value='14'>Evasive Maneuvers</option>
-<option value='15'>Fatal Attraction</option>
-<option value='16'>Fear</option>
-<option value='17'>Fireworks</option>
-<option value='18'>Gift Exchange</option>
-<option value='19'>Going Nuclear</option>
-<option value='20'>Hardened Will</option>
-<option value='21'>Heroes from the Storm</option>
-<option value='22'>Inspiration</option>
-<option value='23'>Just Die</option>
-<option value='24'>Kill Bots</option>
-<option value='25'>Laser Drill</option>
-<option value='26'>Lava Burst</option>
-<option value='27'>Life Leech</option>
-<option value='28'>Long Range</option>
-<option value='29'>Lucky Envelopes</option>
-<option value='30'>Mag-nificent</option>
-<option value='31'>Micro Transactions</option>
-<option value='32'>Mineral Shields</option>
-<option value='33'>Minesweeper</option>
-<option value='34'>Missile Command</option>
-<option value='35'>Moment of Silence</option>
-<option value='36'>Mutually Assured Destruction</option>
-<option value='37'>Naughty List</option>
-<option value='38'>Orbital Strike</option>
-<option value='39'>Outbreak</option>
-<option value='40'>Photon Overload</option>
-<option value='41'>Polarity</option>
-<option value='42'>Power Overwhelming</option>
-<option value='43'>Propagators</option>
-<option value='44'>Purifier Beam</option>
-<option value='45'>Random</option>
-<option value='46'>Scorched Earth</option>
-<option value='47'>Self Destruction</option>
-<option value='48'>Sharing is Caring</option>
-<option value='49'>Shortsighted</option>
-<option value='50'>Slim Pickings</option>
-<option value='51'>Speed Freaks</option>
-<option value='52'>Temporal Field</option>
-<option value='53'>Time Warp</option>
-<option value='54'>Transmutation</option>
-<option value='55'>Trick or Treat</option>
-<option value='56'>Turkey Shoot</option>
-<option value='57'>Twister</option>
-<option value='58'>Vertigo</option>
-<option value='59'>Void Reanimators</option>
-<option value='60'>Void Rifts</option>
-<option value='61'>Walking Infested</option>
-<option value='62'>We Move Unseen</option>
+            <option value='NONE'>-</option>
+<option value='afraidofthedark'>Afraid of the Dark</option>
+<option value='aggressivedeployment'>Aggressive Deployment</option>
+<option value='alienincubation'>Alien Incubation</option>
+<option value='avenger'>Avenger</option>
+<option value='barrier'>Barrier</option>
+<option value='blackdeath'>Black Death</option>
+<option value='blizzard'>Blizzard</option>
+<option value='boombots'>Boom Bots</option>
+<option value='chaosstudios'>Chaos Studios</option>
+<option value='concussiveattacks'>Concussive Attacks</option>
+<option value='darkness'>Darkness</option>
+<option value='diffusion'>Diffusion</option>
+<option value='doubleedged'>Double Edged</option>
+<option value='eminentdomain'>Eminent Domain</option>
+<option value='evasivemaneuvers'>Evasive Maneuvers</option>
+<option value='fatalattraction'>Fatal Attraction</option>
+<option value='fear'>Fear</option>
+<option value='fireworks'>Fireworks</option>
+<option value='giftexchange'>Gift Exchange</option>
+<option value='goingnuclear'>Going Nuclear</option>
+<option value='hardenedwill'>Hardened Will</option>
+<option value='heroesfromthestorm'>Heroes from the Storm</option>
+<option value='inspiration'>Inspiration</option>
+<option value='justdie'>Just Die</option>
+<option value='killbots'>Kill Bots</option>
+<option value='laserdrill'>Laser Drill</option>
+<option value='lavaburst'>Lava Burst</option>
+<option value='lifeleech'>Life Leech</option>
+<option value='longrange'>Long Range</option>
+<option value='luckyenvelopes'>Lucky Envelopes</option>
+<option value='mag-nificent'>Mag-nificent</option>
+<option value='microtransactions'>Micro Transactions</option>
+<option value='mineralshields'>Mineral Shields</option>
+<option value='minesweeper'>Minesweeper</option>
+<option value='missilecommand'>Missile Command</option>
+<option value='momentofsilence'>Moment of Silence</option>
+<option value='mutuallyassureddestruction'>Mutually Assured Destruction</option>
+<option value='naughtylist'>Naughty List</option>
+<option value='orbitalstrike'>Orbital Strike</option>
+<option value='outbreak'>Outbreak</option>
+<option value='photonoverload'>Photon Overload</option>
+<option value='polarity'>Polarity</option>
+<option value='poweroverwhelming'>Power Overwhelming</option>
+<option value='propagators'>Propagators</option>
+<option value='purifierbeam'>Purifier Beam</option>
+<option value='random'>Random</option>
+<option value='scorchedearth'>Scorched Earth</option>
+<option value='selfdestruction'>Self Destruction</option>
+<option value='sharingiscaring'>Sharing is Caring</option>
+<option value='shortsighted'>Shortsighted</option>
+<option value='slimpickings'>Slim Pickings</option>
+<option value='speedfreaks'>Speed Freaks</option>
+<option value='temporalfield'>Temporal Field</option>
+<option value='timewarp'>Time Warp</option>
+<option value='transmutation'>Transmutation</option>
+<option value='trickortreat'>Trick or Treat</option>
+<option value='turkeyshoot'>Turkey Shoot</option>
+<option value='twister'>Twister</option>
+<option value='vertigo'>Vertigo</option>
+<option value='voidreanimators'>Void Reanimators</option>
+<option value='voidrifts'>Void Rifts</option>
+<option value='walkinginfested'>Walking Infested</option>
+<option value='wemoveunseen'>We Move Unseen</option>
         </select>
         <img class="centerAlign" id="mut1img" src="/images/mutators/random.png" height="50" width="50" alt="Mutator 1">
         <p></p>
         <p class="centerAlign" >Mutator 2:</p>
         <select name="mut2" id="mut2">
-            <option value='0'>-</option><option value='-1'>(show all interactions)</option><option value='1'>Afraid of the Dark</option>
-<option value='2'>Aggressive Deployment</option>
-<option value='3'>Alien Incubation</option>
-<option value='4'>Avenger</option>
-<option value='5'>Barrier</option>
-<option value='6'>Black Death</option>
-<option value='7'>Blizzard</option>
-<option value='63'>Boom Bots</option>
-<option value='8'>Chaos Studios</option>
-<option value='9'>Concussive Attacks</option>
-<option value='10'>Darkness</option>
-<option value='11'>Diffusion</option>
-<option value='12'>Double Edged</option>
-<option value='13'>Eminent Domain</option>
-<option value='14'>Evasive Maneuvers</option>
-<option value='15'>Fatal Attraction</option>
-<option value='16'>Fear</option>
-<option value='17'>Fireworks</option>
-<option value='18'>Gift Exchange</option>
-<option value='19'>Going Nuclear</option>
-<option value='20'>Hardened Will</option>
-<option value='21'>Heroes from the Storm</option>
-<option value='22'>Inspiration</option>
-<option value='23'>Just Die</option>
-<option value='24'>Kill Bots</option>
-<option value='25'>Laser Drill</option>
-<option value='26'>Lava Burst</option>
-<option value='27'>Life Leech</option>
-<option value='28'>Long Range</option>
-<option value='29'>Lucky Envelopes</option>
-<option value='30'>Mag-nificent</option>
-<option value='31'>Micro Transactions</option>
-<option value='32'>Mineral Shields</option>
-<option value='33'>Minesweeper</option>
-<option value='34'>Missile Command</option>
-<option value='35'>Moment of Silence</option>
-<option value='36'>Mutually Assured Destruction</option>
-<option value='37'>Naughty List</option>
-<option value='38'>Orbital Strike</option>
-<option value='39'>Outbreak</option>
-<option value='40'>Photon Overload</option>
-<option value='41'>Polarity</option>
-<option value='42'>Power Overwhelming</option>
-<option value='43'>Propagators</option>
-<option value='44'>Purifier Beam</option>
-<option value='45'>Random</option>
-<option value='46'>Scorched Earth</option>
-<option value='47'>Self Destruction</option>
-<option value='48'>Sharing is Caring</option>
-<option value='49'>Shortsighted</option>
-<option value='50'>Slim Pickings</option>
-<option value='51'>Speed Freaks</option>
-<option value='52'>Temporal Field</option>
-<option value='53'>Time Warp</option>
-<option value='54'>Transmutation</option>
-<option value='55'>Trick or Treat</option>
-<option value='56'>Turkey Shoot</option>
-<option value='57'>Twister</option>
-<option value='58'>Vertigo</option>
-<option value='59'>Void Reanimators</option>
-<option value='60'>Void Rifts</option>
-<option value='61'>Walking Infested</option>
-<option value='62'>We Move Unseen</option>
+            <option value='NONE'>-</option>
+<option value='ALL'>(show all interactions)</option>
+<option value='afraidofthedark'>Afraid of the Dark</option>
+<option value='aggressivedeployment'>Aggressive Deployment</option>
+<option value='alienincubation'>Alien Incubation</option>
+<option value='avenger'>Avenger</option>
+<option value='barrier'>Barrier</option>
+<option value='blackdeath'>Black Death</option>
+<option value='blizzard'>Blizzard</option>
+<option value='boombots'>Boom Bots</option>
+<option value='chaosstudios'>Chaos Studios</option>
+<option value='concussiveattacks'>Concussive Attacks</option>
+<option value='darkness'>Darkness</option>
+<option value='diffusion'>Diffusion</option>
+<option value='doubleedged'>Double Edged</option>
+<option value='eminentdomain'>Eminent Domain</option>
+<option value='evasivemaneuvers'>Evasive Maneuvers</option>
+<option value='fatalattraction'>Fatal Attraction</option>
+<option value='fear'>Fear</option>
+<option value='fireworks'>Fireworks</option>
+<option value='giftexchange'>Gift Exchange</option>
+<option value='goingnuclear'>Going Nuclear</option>
+<option value='hardenedwill'>Hardened Will</option>
+<option value='heroesfromthestorm'>Heroes from the Storm</option>
+<option value='inspiration'>Inspiration</option>
+<option value='justdie'>Just Die</option>
+<option value='killbots'>Kill Bots</option>
+<option value='laserdrill'>Laser Drill</option>
+<option value='lavaburst'>Lava Burst</option>
+<option value='lifeleech'>Life Leech</option>
+<option value='longrange'>Long Range</option>
+<option value='luckyenvelopes'>Lucky Envelopes</option>
+<option value='mag-nificent'>Mag-nificent</option>
+<option value='microtransactions'>Micro Transactions</option>
+<option value='mineralshields'>Mineral Shields</option>
+<option value='minesweeper'>Minesweeper</option>
+<option value='missilecommand'>Missile Command</option>
+<option value='momentofsilence'>Moment of Silence</option>
+<option value='mutuallyassureddestruction'>Mutually Assured Destruction</option>
+<option value='naughtylist'>Naughty List</option>
+<option value='orbitalstrike'>Orbital Strike</option>
+<option value='outbreak'>Outbreak</option>
+<option value='photonoverload'>Photon Overload</option>
+<option value='polarity'>Polarity</option>
+<option value='poweroverwhelming'>Power Overwhelming</option>
+<option value='propagators'>Propagators</option>
+<option value='purifierbeam'>Purifier Beam</option>
+<option value='random'>Random</option>
+<option value='scorchedearth'>Scorched Earth</option>
+<option value='selfdestruction'>Self Destruction</option>
+<option value='sharingiscaring'>Sharing is Caring</option>
+<option value='shortsighted'>Shortsighted</option>
+<option value='slimpickings'>Slim Pickings</option>
+<option value='speedfreaks'>Speed Freaks</option>
+<option value='temporalfield'>Temporal Field</option>
+<option value='timewarp'>Time Warp</option>
+<option value='transmutation'>Transmutation</option>
+<option value='trickortreat'>Trick or Treat</option>
+<option value='turkeyshoot'>Turkey Shoot</option>
+<option value='twister'>Twister</option>
+<option value='vertigo'>Vertigo</option>
+<option value='voidreanimators'>Void Reanimators</option>
+<option value='voidrifts'>Void Rifts</option>
+<option value='walkinginfested'>Walking Infested</option>
+<option value='wemoveunseen'>We Move Unseen</option>
         </select>
         <img class="centerAlign"  id="mut2img" src="/images/mutators/random.png" height="50" width="50" alt="Mutator 2">
         <p></p>
@@ -477,7 +480,7 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                 }
             });
             $("#mut1 option").each(function () {
-                var val = parseInt(this.value);
+                var val = this.value;
                 var text = $(this).text();
                 mutators[val] = text;
             });
@@ -489,13 +492,13 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                 mut1 = mut2;
                 mut2 = temp;
             }
-            var key = '' + mut1 + '-' + mut2;
+            var key = mut1 + '-' + mut2;
             return interactionsPairs[key];
         }
         function getAllInteractions(mut) {
             var interactions = {};
             for (var key in mutators) {
-                var interaction = getInteraction(mut, parseInt(key));
+                var interaction = getInteraction(mut, key);
                 if (interaction) {
                     interactions[key] = interaction;
                 }
@@ -505,16 +508,16 @@ if (document.location.host === 'dev.starcraft2coop.com') {
         function updateInteractions() {
             if (!getInteractions()) return;
             var $mut1 = $("#mut1 option:selected");
-            var mut1 = parseInt($mut1.val());
+            var mut1 = $mut1.val();
             var filename1 = $mut1.text().replace(/ /g,'').toLowerCase();
-            if (mut1 <= 0) filename1 = 'random';
+            if (mut1 === "NONE") filename1 = 'random';
             var $mut2 = $("#mut2 option:selected");
-            var mut2 = parseInt($mut2.val());
+            var mut2 = $mut2.val();
             var filename2 = $mut2.text().replace(/ /g,'').toLowerCase();
-            if (mut2 <= 0) filename2 = 'random';
+            if (mut2 === "NONE" || mut2 === "ALL") filename2 = 'random';
             $("#mut2 option").each(function () {
-                var val = parseInt(this.value);
-                if (!val || !mut1 || val === -1 || getInteraction(mut1, val)) {
+                var val = this.value;
+                if (mut1 === "NONE" || val === "NONE" || val === "ALL" || getInteraction(mut1, val)) {
                     this.disabled = false;
                 } else {
                     this.disabled = true;
@@ -522,7 +525,7 @@ if (document.location.host === 'dev.starcraft2coop.com') {
             });
             $("#mut1img").attr("src", "/images/mutators/" + filename1 + ".png");
             $("#mut2img").attr("src", "/images/mutators/" + filename2 + ".png");
-            if (mut1 && mut2 === -1) {
+            if (mut1 !== "NONE" && mut2 === "ALL") {
                 var html = "";
                 var interactions = getAllInteractions(mut1);
                 for (var key in interactions) {
@@ -530,13 +533,13 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
                 $("#interactions").html(html || "No interaction found.");
-            } else if (mut1 && mut2) {
+            } else if (mut1 !== "NONE" && mut2 !== "NONE") {
                 $("#interactions").text(getInteraction(mut1, mut2) || "No interaction found.");
-            } else if (mut1 && !$mut2.length) {
+            } else if (mut1 !== "NONE" && !$mut2.length) {
                 // mut2 has a disabled option selected, which means there's no interaction
                 $("#interactions").text("No interaction found.");
             } else {
-                $("#interactions").text(mut1 || mut2 ? "(Select both mutators)" : "");
+                $("#interactions").text((mut1 === "NONE") !== (mut2 === "NONE") ? "(Select both mutators)" : "");
             }
         }
         $("#mut1").change(function(){

--- a/html/resources/mutators.html
+++ b/html/resources/mutators.html
@@ -492,7 +492,7 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                 mut1 = mut2;
                 mut2 = temp;
             }
-            var key = mut1 + '-' + mut2;
+            var key = '' + mut1 + '-' + mut2;
             return interactionsPairs[key];
         }
         function getAllInteractions(mut) {
@@ -509,12 +509,10 @@ if (document.location.host === 'dev.starcraft2coop.com') {
             if (!getInteractions()) return;
             var $mut1 = $("#mut1 option:selected");
             var mut1 = $mut1.val();
-            var filename1 = $mut1.text().replace(/ /g,'').toLowerCase();
-            if (mut1 === "NONE") filename1 = 'random';
+            var filename1 = mut1 === "NONE" ? 'random' : mut1;
             var $mut2 = $("#mut2 option:selected");
             var mut2 = $mut2.val();
-            var filename2 = $mut2.text().replace(/ /g,'').toLowerCase();
-            if (mut2 === "NONE" || mut2 === "ALL") filename2 = 'random';
+            var filename2 = mut2 === "NONE" || mut2 === "ALL" ? 'random' : mut2
             $("#mut2 option").each(function () {
                 var val = this.value;
                 if (mut1 === "NONE" || val === "NONE" || val === "ALL" || getInteraction(mut1, val)) {
@@ -529,7 +527,7 @@ if (document.location.host === 'dev.starcraft2coop.com') {
                 var html = "";
                 var interactions = getAllInteractions(mut1);
                 for (var key in interactions) {
-                    var filename = mutators[key].replace(/ /g,'').toLowerCase();
+                    var filename = key;
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
                 $("#interactions").html(html || "No interaction found.");

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -170,14 +170,15 @@ require_once "../wrapper-static.php";
     usort($mutatorInfo, fn($a, $b) => $a['mutatorname'] <=> $b['mutatorname']);
     $mutators = [];
     foreach ($mutatorInfo as $mutator) {
-        $mutators[] = [$mutator['mutatorid'],$mutator['mutatorname']];
+        // TODO: when de-database-ifying mutators, use the human-ish id and remove the conversion here
+        $mutators[] = [str_replace(' ', '', strtolower($mutator['mutatorname'])) ,$mutator['mutatorname']];
     }
     ?>
     <form action="mutators.php" method="post">
         <p class="centerAlign">Mutator 1:</p>
         <select name="mut1" id="mut1">
             <?php
-            echo "<option value='0'>-</option>";
+            echo "<option value='NONE'>-</option>\n";
             foreach ($mutators as [$id, $name]) {
                 echo "<option value='$id'>$name</option>\n";
             }
@@ -188,8 +189,8 @@ require_once "../wrapper-static.php";
         <p class="centerAlign" >Mutator 2:</p>
         <select name="mut2" id="mut2">
             <?php
-            echo "<option value='0'>-</option>";
-            echo "<option value='-1'>(show all interactions)</option>";
+            echo "<option value='NONE'>-</option>\n";
+            echo "<option value='ALL'>(show all interactions)</option>\n";
             foreach ($mutators as [$id, $name]) {
                 echo "<option value='$id'>$name</option>\n";
             }
@@ -223,7 +224,7 @@ require_once "../wrapper-static.php";
                 }
             });
             $("#mut1 option").each(function () {
-                var val = parseInt(this.value);
+                var val = this.value;
                 var text = $(this).text();
                 mutators[val] = text;
             });
@@ -235,13 +236,13 @@ require_once "../wrapper-static.php";
                 mut1 = mut2;
                 mut2 = temp;
             }
-            var key = '' + mut1 + '-' + mut2;
+            var key = mut1 + '-' + mut2;
             return interactionsPairs[key];
         }
         function getAllInteractions(mut) {
             var interactions = {};
             for (var key in mutators) {
-                var interaction = getInteraction(mut, parseInt(key));
+                var interaction = getInteraction(mut, key);
                 if (interaction) {
                     interactions[key] = interaction;
                 }
@@ -251,16 +252,16 @@ require_once "../wrapper-static.php";
         function updateInteractions() {
             if (!getInteractions()) return;
             var $mut1 = $("#mut1 option:selected");
-            var mut1 = parseInt($mut1.val());
+            var mut1 = $mut1.val();
             var filename1 = $mut1.text().replace(/ /g,'').toLowerCase();
-            if (mut1 <= 0) filename1 = 'random';
+            if (mut1 === "NONE") filename1 = 'random';
             var $mut2 = $("#mut2 option:selected");
-            var mut2 = parseInt($mut2.val());
+            var mut2 = $mut2.val();
             var filename2 = $mut2.text().replace(/ /g,'').toLowerCase();
-            if (mut2 <= 0) filename2 = 'random';
+            if (mut2 === "NONE" || mut2 === "ALL") filename2 = 'random';
             $("#mut2 option").each(function () {
-                var val = parseInt(this.value);
-                if (!val || !mut1 || val === -1 || getInteraction(mut1, val)) {
+                var val = this.value;
+                if (mut1 === "NONE" || val === "NONE" || val === "ALL" || getInteraction(mut1, val)) {
                     this.disabled = false;
                 } else {
                     this.disabled = true;
@@ -268,7 +269,7 @@ require_once "../wrapper-static.php";
             });
             $("#mut1img").attr("src", "/images/mutators/" + filename1 + ".png");
             $("#mut2img").attr("src", "/images/mutators/" + filename2 + ".png");
-            if (mut1 && mut2 === -1) {
+            if (mut1 !== "NONE" && mut2 === "ALL") {
                 var html = "";
                 var interactions = getAllInteractions(mut1);
                 for (var key in interactions) {
@@ -276,13 +277,13 @@ require_once "../wrapper-static.php";
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
                 $("#interactions").html(html || "No interaction found.");
-            } else if (mut1 && mut2) {
+            } else if (mut1 !== "NONE" && mut2 !== "NONE") {
                 $("#interactions").text(getInteraction(mut1, mut2) || "No interaction found.");
-            } else if (mut1 && !$mut2.length) {
+            } else if (mut1 !== "NONE" && !$mut2.length) {
                 // mut2 has a disabled option selected, which means there's no interaction
                 $("#interactions").text("No interaction found.");
             } else {
-                $("#interactions").text(mut1 || mut2 ? "(Select both mutators)" : "");
+                $("#interactions").text((mut1 === "NONE") !== (mut2 === "NONE") ? "(Select both mutators)" : "");
             }
         }
         $("#mut1").change(function(){

--- a/html/resources/mutators.php
+++ b/html/resources/mutators.php
@@ -171,7 +171,7 @@ require_once "../wrapper-static.php";
     $mutators = [];
     foreach ($mutatorInfo as $mutator) {
         // TODO: when de-database-ifying mutators, use the human-ish id and remove the conversion here
-        $mutators[] = [str_replace(' ', '', strtolower($mutator['mutatorname'])) ,$mutator['mutatorname']];
+        $mutators[] = [str_replace(' ', '', strtolower($mutator['mutatorname'])), $mutator['mutatorname']];
     }
     ?>
     <form action="mutators.php" method="post">
@@ -236,7 +236,7 @@ require_once "../wrapper-static.php";
                 mut1 = mut2;
                 mut2 = temp;
             }
-            var key = mut1 + '-' + mut2;
+            var key = '' + mut1 + '-' + mut2;
             return interactionsPairs[key];
         }
         function getAllInteractions(mut) {
@@ -253,12 +253,10 @@ require_once "../wrapper-static.php";
             if (!getInteractions()) return;
             var $mut1 = $("#mut1 option:selected");
             var mut1 = $mut1.val();
-            var filename1 = $mut1.text().replace(/ /g,'').toLowerCase();
-            if (mut1 === "NONE") filename1 = 'random';
+            var filename1 = mut1 === "NONE" ? 'random' : mut1;
             var $mut2 = $("#mut2 option:selected");
             var mut2 = $mut2.val();
-            var filename2 = $mut2.text().replace(/ /g,'').toLowerCase();
-            if (mut2 === "NONE" || mut2 === "ALL") filename2 = 'random';
+            var filename2 = mut2 === "NONE" || mut2 === "ALL" ? 'random' : mut2
             $("#mut2 option").each(function () {
                 var val = this.value;
                 if (mut1 === "NONE" || val === "NONE" || val === "ALL" || getInteraction(mut1, val)) {
@@ -273,7 +271,7 @@ require_once "../wrapper-static.php";
                 var html = "";
                 var interactions = getAllInteractions(mut1);
                 for (var key in interactions) {
-                    var filename = mutators[key].replace(/ /g,'').toLowerCase();
+                    var filename = key;
                     html += "<p><img src=\"/images/mutators/" + filename + ".png\" height=\"25\" width=\"25\" style=\"vertical-align:middle\"> " + mutators[key] + ": " + interactions[key] + "</p>";
                 }
                 $("#interactions").html(html || "No interaction found.");

--- a/source-data/data-types.ts
+++ b/source-data/data-types.ts
@@ -68,10 +68,12 @@ export interface Commander {
 export type CommanderList = Commander[];
 
 export interface MutatorInteraction {
-    /** ID of the first mutator in the pair */
-    id1: MutatorId;
-    /** ID of the second mutator in the pair (id2 > id1) */
-    id2: MutatorId;
+    /** ID of the first mutator in the pair, Normalized
+     * @pattern ^[a-z0-9]+$ */
+    id1: string;
+    /** ID of the second mutator in the pair, Normalized & id2 > id1
+     * @pattern ^[a-z0-9]+$ */
+    id2: string;
     /** Description of how the two mutators interact */
     interaction: string;
 }

--- a/source-data/data-types.ts
+++ b/source-data/data-types.ts
@@ -10,9 +10,10 @@ export type PositiveInteger = number;
 export type NonNegativeInteger = number;
 export type CommanderPowerRating = 1 | 2 | 3 | 4 | 5;
 /**
- * @asType string
+ * @pattern ^[^ A-Z]+$
  */
-export type MutatorId = Lowercase<string>;
+export type LowercaseNoSpaces = string;
+export type MutatorId = LowercaseNoSpaces;
 
 export interface BrutalPlus {
     /** as in, the X in Brutal+X */
@@ -68,12 +69,10 @@ export interface Commander {
 export type CommanderList = Commander[];
 
 export interface MutatorInteraction {
-    /** ID of the first mutator in the pair, Normalized
-     * @pattern ^[a-z0-9]+$ */
-    id1: string;
-    /** ID of the second mutator in the pair, Normalized & id2 > id1
-     * @pattern ^[a-z0-9]+$ */
-    id2: string;
+    /** ID of the first mutator in the pair, lowercased & without spaces */
+    id1: MutatorId;
+    /** ID of the second mutator in the pair, lowercased & without spaces, id2 > id1 */
+    id2: MutatorId;
     /** Description of how the two mutators interact */
     interaction: string;
 }

--- a/source-data/data-types.ts
+++ b/source-data/data-types.ts
@@ -9,6 +9,10 @@ export type PositiveInteger = number;
  */
 export type NonNegativeInteger = number;
 export type CommanderPowerRating = 1 | 2 | 3 | 4 | 5;
+/**
+ * @asType string
+ */
+export type MutatorId = Lowercase<string>;
 
 export interface BrutalPlus {
     /** as in, the X in Brutal+X */
@@ -65,9 +69,9 @@ export type CommanderList = Commander[];
 
 export interface MutatorInteraction {
     /** ID of the first mutator in the pair */
-    id1: PositiveInteger;
+    id1: MutatorId;
     /** ID of the second mutator in the pair (id2 > id1) */
-    id2: PositiveInteger;
+    id2: MutatorId;
     /** Description of how the two mutators interact */
     interaction: string;
 }

--- a/source-data/mutatorinteractions.json
+++ b/source-data/mutatorinteractions.json
@@ -795,8 +795,8 @@
     "interaction": "Infested apply the Concussive Attacks debuff."
   },
   {
-    "id1": "concussiveattacks",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "concussiveattacks",
     "interaction": "Boom Bots apply the Concussive Attacks debuff."
   },
   {
@@ -845,8 +845,8 @@
     "interaction": "Void Rifts are marked on the minimap."
   },
   {
-    "id1": "darkness",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "darkness",
     "interaction": "Boom Bots do not appear on the minimap."
   },
   {
@@ -955,8 +955,8 @@
     "interaction": "Void Reanimators spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": "eminentdomain",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "eminentdomain",
     "interaction": "Boom Bots spawn out of structures converted by Eminent Domain."
   },
   {
@@ -1115,8 +1115,8 @@
     "interaction": "Infested trigger Fatal Attraction when they die."
   },
   {
-    "id1": "fatalattraction",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "fatalattraction",
     "interaction": "Boom Bots trigger Fatal Attraction when they die."
   },
   {
@@ -1240,8 +1240,8 @@
     "interaction": "Infested can apply the Fear effect."
   },
   {
-    "id1": "fear",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "fear",
     "interaction": "Boom Bots do not apply the Fear effect."
   },
   {
@@ -1310,8 +1310,8 @@
     "interaction": "Infested do not launch Fireworks when they die."
   },
   {
-    "id1": "fireworks",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "fireworks",
     "interaction": "Boom Bots launch Fireworks when they die."
   },
   {
@@ -1475,8 +1475,8 @@
     "interaction": "Units spawned from Gift Exchange are cloaked."
   },
   {
-    "id1": "giftexchange",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "giftexchange",
     "interaction": "Boom Bots do not capture gifts."
   },
   {
@@ -1550,8 +1550,8 @@
     "interaction": "Infested cause Hardened Will to activate."
   },
   {
-    "id1": "hardenedwill",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "hardenedwill",
     "interaction": "Boom Bots do not get the Hardened Will buff."
   },
   {
@@ -1680,8 +1680,8 @@
     "interaction": "Infested can get the Inspiration buff."
   },
   {
-    "id1": "inspiration",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "inspiration",
     "interaction": "Boom Bots do not provide the Inspiration buff."
   },
   {
@@ -1790,8 +1790,8 @@
     "interaction": "Respawned units are cloaked."
   },
   {
-    "id1": "justdie",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "justdie",
     "interaction": "Boom Bots do not respawn when they self-destruct."
   },
   {
@@ -1955,8 +1955,8 @@
     "interaction": "Infested provide vision for the Laser Drill."
   },
   {
-    "id1": "laserdrill",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "laserdrill",
     "interaction": "Boom Bots provide vision for the Laser Drill.\r\nBoom Bots do not spawn from the Laser Drill."
   },
   {
@@ -2220,8 +2220,8 @@
     "interaction": "Hybrids spawned from Void Rifts trigger Moment of Silence when they die."
   },
   {
-    "id1": "momentofsilence",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "momentofsilence",
     "interaction": "Boom Bots do not trigger Moment of Silence when they die."
   },
   {
@@ -2400,8 +2400,8 @@
     "interaction": "Infested can cast abilities."
   },
   {
-    "id1": "poweroverwhelming",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "poweroverwhelming",
     "interaction": "Boom Bots can cast abilities. Boom Bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
@@ -2480,8 +2480,8 @@
     "interaction": "Infested set the ground on fire when they die."
   },
   {
-    "id1": "scorchedearth",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "scorchedearth",
     "interaction": "Boom Bots set the ground on fire when they die."
   },
   {
@@ -2510,8 +2510,8 @@
     "interaction": "Infested create an explosion when they die."
   },
   {
-    "id1": "selfdestruction",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "selfdestruction",
     "interaction": "Boom Bots create an explosion when they die."
   },
   {
@@ -2545,8 +2545,8 @@
     "interaction": "Infested units move faster with Speed Freaks."
   },
   {
-    "id1": "speedfreaks",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "speedfreaks",
     "interaction": "Boom Bots move faster with Speed Freaks."
   },
   {
@@ -2645,8 +2645,8 @@
     "interaction": "Void Reanimators are cloaked."
   },
   {
-    "id1": "voidreanimators",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not resurrect Boom Bots."
   },
   {
@@ -2660,8 +2660,8 @@
     "interaction": "Units spawned from Void Rifts are cloaked."
   },
   {
-    "id1": "voidrifts",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "voidrifts",
     "interaction": "Boom Bots do not spawn from Void Rifts."
   },
   {
@@ -2670,13 +2670,13 @@
     "interaction": "Infested are cloaked."
   },
   {
-    "id1": "walkinginfested",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "walkinginfested",
     "interaction": "Boom Bots spawn Infested when they die."
   },
   {
-    "id1": "wemoveunseen",
-    "id2": "boombots",
+    "id1": "boombots",
+    "id2": "wemoveunseen",
     "interaction": "Boom Bots are cloaked, but their tags are still visible.\r\nCodes cannot be input without detection."
   }
 ]

--- a/source-data/mutatorinteractions.json
+++ b/source-data/mutatorinteractions.json
@@ -1,2682 +1,2682 @@
 [
   {
-    "id1": 1,
-    "id2": 7,
+    "id1": "afraidofthedark",
+    "id2": "blizzard",
     "interaction": "Blizzards appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 18,
+    "id1": "afraidofthedark",
+    "id2": "giftexchange",
     "interaction": "Gifts do not appear on the minimap. Kill Bots gifted to Amon do not appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 24,
+    "id1": "afraidofthedark",
+    "id2": "killbots",
     "interaction": "Kill Bots do not appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 25,
+    "id1": "afraidofthedark",
+    "id2": "laserdrill",
     "interaction": "The Laser Drill will be marked on the minimap when it attacks you."
   },
   {
-    "id1": 1,
-    "id2": 30,
+    "id1": "afraidofthedark",
+    "id2": "magnificent",
     "interaction": "Mag-mines appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 34,
+    "id1": "afraidofthedark",
+    "id2": "missilecommand",
     "interaction": "Missiles do not appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 43,
+    "id1": "afraidofthedark",
+    "id2": "propagators",
     "interaction": "Propagators do not appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 44,
+    "id1": "afraidofthedark",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam appears as a red dot on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 56,
+    "id1": "afraidofthedark",
+    "id2": "turkeyshoot",
     "interaction": "The Turking does not appear on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 60,
+    "id1": "afraidofthedark",
+    "id2": "voidrifts",
     "interaction": "Void Rifts are marked on the minimap."
   },
   {
-    "id1": 1,
-    "id2": 63,
+    "id1": "afraidofthedark",
+    "id2": "boombots",
     "interaction": "Boom Bots do not appear on the minimap."
   },
   {
-    "id1": 2,
-    "id2": 3,
+    "id1": "aggressivedeployment",
+    "id2": "alienincubation",
     "interaction": "Units from Aggressive Deployment Drops spawn Broodlings when they die."
   },
   {
-    "id1": 2,
-    "id2": 4,
+    "id1": "aggressivedeployment",
+    "id2": "avenger",
     "interaction": "Units from Aggressive Deployment Drops give out and receive Avenger stacks."
   },
   {
-    "id1": 2,
-    "id2": 5,
+    "id1": "aggressivedeployment",
+    "id2": "barrier",
     "interaction": "Units from Aggressive Deployment Drops get the Barrier buff."
   },
   {
-    "id1": 2,
-    "id2": 6,
+    "id1": "aggressivedeployment",
+    "id2": "blackdeath",
     "interaction": "Units from Aggressive Deployment Drops can carry Plague."
   },
   {
-    "id1": 2,
-    "id2": 8,
+    "id1": "aggressivedeployment",
+    "id2": "chaosstudios",
     "interaction": "A single 1/1 Aggressive Deployment drop will spawn once the mutator rolls out."
   },
   {
-    "id1": 2,
-    "id2": 9,
+    "id1": "aggressivedeployment",
+    "id2": "concussiveattacks",
     "interaction": "Units from Aggressive Deployment Drops apply the Concussive Attacks debuff."
   },
   {
-    "id1": 2,
-    "id2": 14,
+    "id1": "aggressivedeployment",
+    "id2": "evasivemaneuvers",
     "interaction": "Units from Aggressive Deployment Drops get the Evasive Maneuvers buff."
   },
   {
-    "id1": 2,
-    "id2": 15,
+    "id1": "aggressivedeployment",
+    "id2": "fatalattraction",
     "interaction": "Units from Aggressive Deployment Drops trigger Fatal Attraction when they die."
   },
   {
-    "id1": 2,
-    "id2": 16,
+    "id1": "aggressivedeployment",
+    "id2": "fear",
     "interaction": "Units from Aggressive Deployment Drops can apply the Fear effect."
   },
   {
-    "id1": 2,
-    "id2": 17,
+    "id1": "aggressivedeployment",
+    "id2": "fireworks",
     "interaction": "Units from Aggressive Deployment Drops do not launch Fireworks when they die."
   },
   {
-    "id1": 2,
-    "id2": 18,
+    "id1": "aggressivedeployment",
+    "id2": "giftexchange",
     "interaction": "Units from Aggressive Deployment Drops can capture gifts."
   },
   {
-    "id1": 2,
-    "id2": 20,
+    "id1": "aggressivedeployment",
+    "id2": "hardenedwill",
     "interaction": "Units from Aggressive Deployment Drops cause Hardened Will to activate."
   },
   {
-    "id1": 2,
-    "id2": 21,
+    "id1": "aggressivedeployment",
+    "id2": "heroesfromthestorm",
     "interaction": "Aggressive Deployment drops do not contain Amon Heroes."
   },
   {
-    "id1": 2,
-    "id2": 22,
+    "id1": "aggressivedeployment",
+    "id2": "inspiration",
     "interaction": "Units from Aggressive Deployment Drops can get the Inspiration buff."
   },
   {
-    "id1": 2,
-    "id2": 23,
+    "id1": "aggressivedeployment",
+    "id2": "justdie",
     "interaction": "Units from Aggressive Deployment Drops respawn when they die."
   },
   {
-    "id1": 2,
-    "id2": 27,
+    "id1": "aggressivedeployment",
+    "id2": "lifeleech",
     "interaction": "Units from Aggressive Deployment Drops have the Life Leech buff."
   },
   {
-    "id1": 2,
-    "id2": 28,
+    "id1": "aggressivedeployment",
+    "id2": "longrange",
     "interaction": "Units from Aggressive Deployment Drops get the Long Range buff."
   },
   {
-    "id1": 2,
-    "id2": 37,
+    "id1": "aggressivedeployment",
+    "id2": "naughtylist",
     "interaction": "Aggressive Deployment Drop kills increase the Naughty List count."
   },
   {
-    "id1": 2,
-    "id2": 41,
+    "id1": "aggressivedeployment",
+    "id2": "polarity",
     "interaction": "Units from Aggressive Deployment Drops all have Polarity applied to them."
   },
   {
-    "id1": 2,
-    "id2": 42,
+    "id1": "aggressivedeployment",
+    "id2": "poweroverwhelming",
     "interaction": "Units from Aggressive Deployment Drops move can cast skills."
   },
   {
-    "id1": 2,
-    "id2": 46,
+    "id1": "aggressivedeployment",
+    "id2": "scorchedearth",
     "interaction": "Units from Aggressive Deployment Drops set the ground on fire when they die."
   },
   {
-    "id1": 2,
-    "id2": 47,
+    "id1": "aggressivedeployment",
+    "id2": "selfdestruction",
     "interaction": "Units from Aggressive Deployment Drops create an explosion when they die."
   },
   {
-    "id1": 2,
-    "id2": 51,
+    "id1": "aggressivedeployment",
+    "id2": "speedfreaks",
     "interaction": "Units from Aggressive Deployment Drops move faster with Speed Freaks."
   },
   {
-    "id1": 2,
-    "id2": 54,
+    "id1": "aggressivedeployment",
+    "id2": "transmutation",
     "interaction": "Units from Aggressive Deployment Drops can Transmute."
   },
   {
-    "id1": 2,
-    "id2": 59,
+    "id1": "aggressivedeployment",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can resurrect units from Aggressive Deployment Drops."
   },
   {
-    "id1": 2,
-    "id2": 61,
+    "id1": "aggressivedeployment",
+    "id2": "walkinginfested",
     "interaction": "Units from Aggressive Deployment Drops spawn Infested when they die."
   },
   {
-    "id1": 2,
-    "id2": 62,
+    "id1": "aggressivedeployment",
+    "id2": "wemoveunseen",
     "interaction": "Units from Aggressive Deployment Drops are cloaked."
   },
   {
-    "id1": 3,
-    "id2": 4,
+    "id1": "alienincubation",
+    "id2": "avenger",
     "interaction": "Broodlings can give out/receive Avenger stacks."
   },
   {
-    "id1": 3,
-    "id2": 5,
+    "id1": "alienincubation",
+    "id2": "barrier",
     "interaction": "Broodlings get the Barrier buff."
   },
   {
-    "id1": 3,
-    "id2": 6,
+    "id1": "alienincubation",
+    "id2": "blackdeath",
     "interaction": "Broodlings can carry Plague."
   },
   {
-    "id1": 3,
-    "id2": 14,
+    "id1": "alienincubation",
+    "id2": "evasivemaneuvers",
     "interaction": "Broodlings get the Evasive Maneuvers buff."
   },
   {
-    "id1": 3,
-    "id2": 15,
+    "id1": "alienincubation",
+    "id2": "fatalattraction",
     "interaction": "Broodlings trigger Fatal Attraction when they die."
   },
   {
-    "id1": 3,
-    "id2": 16,
+    "id1": "alienincubation",
+    "id2": "fear",
     "interaction": "Broodlings can apply the Fear effect."
   },
   {
-    "id1": 3,
-    "id2": 17,
+    "id1": "alienincubation",
+    "id2": "fireworks",
     "interaction": "Broodlings launch Fireworks when they die."
   },
   {
-    "id1": 3,
-    "id2": 18,
+    "id1": "alienincubation",
+    "id2": "giftexchange",
     "interaction": "Broodlings can capture gifts. Units spawned from Gift Exchange spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 20,
+    "id1": "alienincubation",
+    "id2": "hardenedwill",
     "interaction": "Broodlings cause Hardened Will to activate."
   },
   {
-    "id1": 3,
-    "id2": 21,
+    "id1": "alienincubation",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 22,
+    "id1": "alienincubation",
+    "id2": "inspiration",
     "interaction": "Broodlings can get the Inspiration buff."
   },
   {
-    "id1": 3,
-    "id2": 23,
+    "id1": "alienincubation",
+    "id2": "justdie",
     "interaction": "Broodlings respawn when they die."
   },
   {
-    "id1": 3,
-    "id2": 24,
+    "id1": "alienincubation",
+    "id2": "killbots",
     "interaction": "Kill Bots spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 27,
+    "id1": "alienincubation",
+    "id2": "lifeleech",
     "interaction": "Broodlings have Life Leech."
   },
   {
-    "id1": 3,
-    "id2": 30,
+    "id1": "alienincubation",
+    "id2": "magnificent",
     "interaction": "Mag-mines do not spawn Broodlings when they detonate."
   },
   {
-    "id1": 3,
-    "id2": 33,
+    "id1": "alienincubation",
+    "id2": "minesweeper",
     "interaction": "Mines spawn Broodlings when they are destroyed."
   },
   {
-    "id1": 3,
-    "id2": 34,
+    "id1": "alienincubation",
+    "id2": "missilecommand",
     "interaction": "Missiles do not spawn Broodlings when destroyed."
   },
   {
-    "id1": 3,
-    "id2": 37,
+    "id1": "alienincubation",
+    "id2": "naughtylist",
     "interaction": "Broodling kills increase the Naughty List count."
   },
   {
-    "id1": 3,
-    "id2": 39,
+    "id1": "alienincubation",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations do not spawn Broodlings units when killed."
   },
   {
-    "id1": 3,
-    "id2": 41,
+    "id1": "alienincubation",
+    "id2": "polarity",
     "interaction": "Broodlings all have Polarity applied to them."
   },
   {
-    "id1": 3,
-    "id2": 42,
+    "id1": "alienincubation",
+    "id2": "poweroverwhelming",
     "interaction": "Broodlings can cast abilities."
   },
   {
-    "id1": 3,
-    "id2": 43,
+    "id1": "alienincubation",
+    "id2": "propagators",
     "interaction": "Propagators spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 46,
+    "id1": "alienincubation",
+    "id2": "scorchedearth",
     "interaction": "Broodlings set the ground on fire when they die."
   },
   {
-    "id1": 3,
-    "id2": 47,
+    "id1": "alienincubation",
+    "id2": "selfdestruction",
     "interaction": "Broodlings create an explosion when they die."
   },
   {
-    "id1": 3,
-    "id2": 51,
+    "id1": "alienincubation",
+    "id2": "speedfreaks",
     "interaction": "Broodlings move faster with Speed Freaks."
   },
   {
-    "id1": 3,
-    "id2": 54,
+    "id1": "alienincubation",
+    "id2": "transmutation",
     "interaction": "Broodlings can transmutate. Newly-transmuted units spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 55,
+    "id1": "alienincubation",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 56,
+    "id1": "alienincubation",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not spawn Broodlings when they die. Angry Turkeys spawn Broodlings when they die. The Turking does not spawn Broodlings when it dies."
   },
   {
-    "id1": 3,
-    "id2": 59,
+    "id1": "alienincubation",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators cannot resurrect Broodlings."
   },
   {
-    "id1": 3,
-    "id2": 60,
+    "id1": "alienincubation",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts spawn Broodlings when they die."
   },
   {
-    "id1": 3,
-    "id2": 61,
+    "id1": "alienincubation",
+    "id2": "walkinginfested",
     "interaction": "Killed units spawn both, Infested and Broodlings at the same time. Infested units and Broodlings do not spawn units on death."
   },
   {
-    "id1": 3,
-    "id2": 62,
+    "id1": "alienincubation",
+    "id2": "wemoveunseen",
     "interaction": "Broodlings are cloaked."
   },
   {
-    "id1": 3,
-    "id2": 63,
+    "id1": "alienincubation",
+    "id2": "boombots",
     "interaction": "Boom Bots spawn Broodlings when they die."
   },
   {
-    "id1": 4,
-    "id2": 18,
+    "id1": "avenger",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange can give out/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 21,
+    "id1": "avenger",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes can give out (1 stack)/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 22,
+    "id1": "avenger",
+    "id2": "inspiration",
     "interaction": "Units with Avenger stacks can get the Inspiration buff."
   },
   {
-    "id1": 4,
-    "id2": 23,
+    "id1": "avenger",
+    "id2": "justdie",
     "interaction": "Units do not give out/lose Avenger stacks when taking fatal damage and respawning. When a unit is finally killed, Avenger stacks are provided to surrounding units. Units retain their Avenger stacks when taking fatal damage and respawning."
   },
   {
-    "id1": 4,
-    "id2": 24,
+    "id1": "avenger",
+    "id2": "killbots",
     "interaction": "Kill Bots can give out Avenger stacks (1 stack) when they die."
   },
   {
-    "id1": 4,
-    "id2": 30,
+    "id1": "avenger",
+    "id2": "magnificent",
     "interaction": "Mag-mines do not give out Avenger stacks when they detonate."
   },
   {
-    "id1": 4,
-    "id2": 33,
+    "id1": "avenger",
+    "id2": "minesweeper",
     "interaction": "Mines can give out Avenger stacks, but cannot receive them."
   },
   {
-    "id1": 4,
-    "id2": 34,
+    "id1": "avenger",
+    "id2": "missilecommand",
     "interaction": "Missiles do not give out Avenger stacks when destroyed."
   },
   {
-    "id1": 4,
-    "id2": 39,
+    "id1": "avenger",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations can give out/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 43,
+    "id1": "avenger",
+    "id2": "propagators",
     "interaction": "Propagators can give out (1 stack)/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 51,
+    "id1": "avenger",
+    "id2": "speedfreaks",
     "interaction": "Units with Avenger stacks move faster with Speed Freaks."
   },
   {
-    "id1": 4,
-    "id2": 54,
+    "id1": "avenger",
+    "id2": "transmutation",
     "interaction": "Units lose their Avenger stacks after they Transmute."
   },
   {
-    "id1": 4,
-    "id2": 55,
+    "id1": "avenger",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians give out and collect Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 56,
+    "id1": "avenger",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not give out Avenger stacks. Angry Turkeys can give out (1 stack)/receive Avenger stacks. The Turking can give out (10 stacks) Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 59,
+    "id1": "avenger",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can give out (3 stacks) Avenger stacks. Resurrected units do not keep their Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 60,
+    "id1": "avenger",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can give out/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 61,
+    "id1": "avenger",
+    "id2": "walkinginfested",
     "interaction": "Infested can give out/receive Avenger stacks."
   },
   {
-    "id1": 4,
-    "id2": 63,
+    "id1": "avenger",
+    "id2": "boombots",
     "interaction": "Boom Bots do not give out Avenger stacks when they die."
   },
   {
-    "id1": 5,
-    "id2": 13,
+    "id1": "barrier",
+    "id2": "eminentdomain",
     "interaction": "Structures captured by Amon get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 18,
+    "id1": "barrier",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 21,
+    "id1": "barrier",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 23,
+    "id1": "barrier",
+    "id2": "justdie",
     "interaction": "If a unit has used its Barrier buff, the respawned unit will not get the Barrier buff. If a unit has not used its Barrier buff, the respawned unit will have the Barrier buff activated when it respawns."
   },
   {
-    "id1": 5,
-    "id2": 32,
+    "id1": "barrier",
+    "id2": "mineralshields",
     "interaction": "Mineral Shields get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 33,
+    "id1": "barrier",
+    "id2": "minesweeper",
     "interaction": "Mines get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 34,
+    "id1": "barrier",
+    "id2": "missilecommand",
     "interaction": "Missiles get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 39,
+    "id1": "barrier",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 41,
+    "id1": "barrier",
+    "id2": "polarity",
     "interaction": "Damage blocked by Polarity still triggers Barrier."
   },
   {
-    "id1": 5,
-    "id2": 43,
+    "id1": "barrier",
+    "id2": "propagators",
     "interaction": "Propagators get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 54,
+    "id1": "barrier",
+    "id2": "transmutation",
     "interaction": "Transmuted units get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 55,
+    "id1": "barrier",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 56,
+    "id1": "barrier",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 59,
+    "id1": "barrier",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators get the Barrier buff. Resurrected units get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 60,
+    "id1": "barrier",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts get the Barrier buff."
   },
   {
-    "id1": 5,
-    "id2": 61,
+    "id1": "barrier",
+    "id2": "walkinginfested",
     "interaction": "Infested get the Barrier buff."
   },
   {
-    "id1": 6,
-    "id2": 12,
+    "id1": "blackdeath",
+    "id2": "doubleedged",
     "interaction": "Units with Black Death will die twice as fast with Double Edged active."
   },
   {
-    "id1": 6,
-    "id2": 16,
+    "id1": "blackdeath",
+    "id2": "fear",
     "interaction": "Plague damage ticks do not have a chance of applying Fear."
   },
   {
-    "id1": 6,
-    "id2": 18,
+    "id1": "blackdeath",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 21,
+    "id1": "blackdeath",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 23,
+    "id1": "blackdeath",
+    "id2": "justdie",
     "interaction": "Whether a unit has Plague or not is retained when it takes fatal damage. Plague only spreads when the unit is finnally killed."
   },
   {
-    "id1": 6,
-    "id2": 24,
+    "id1": "blackdeath",
+    "id2": "killbots",
     "interaction": "Kill Bots cannot carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 30,
+    "id1": "blackdeath",
+    "id2": "magnificent",
     "interaction": "Mag-mines cannot carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 33,
+    "id1": "blackdeath",
+    "id2": "minesweeper",
     "interaction": "Mines can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 34,
+    "id1": "blackdeath",
+    "id2": "missilecommand",
     "interaction": "Missiles cannot carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 39,
+    "id1": "blackdeath",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 43,
+    "id1": "blackdeath",
+    "id2": "propagators",
     "interaction": "Propagators can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 54,
+    "id1": "blackdeath",
+    "id2": "transmutation",
     "interaction": "Transmuted units may or may not carry Plague, irrespective of whether it carried Plague or not before Transmuting."
   },
   {
-    "id1": 6,
-    "id2": 55,
+    "id1": "blackdeath",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 56,
+    "id1": "blackdeath",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys cannot carry Plague. The Turking can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 59,
+    "id1": "blackdeath",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can carry Plague. Resurrected units may or may not carry Plague, irrespective of whether it originally carried Plague or not before it died."
   },
   {
-    "id1": 6,
-    "id2": 60,
+    "id1": "blackdeath",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 61,
+    "id1": "blackdeath",
+    "id2": "walkinginfested",
     "interaction": "Infested can carry Plague."
   },
   {
-    "id1": 6,
-    "id2": 63,
+    "id1": "blackdeath",
+    "id2": "boombots",
     "interaction": "Boom Bots cannot carry Plague."
   },
   {
-    "id1": 7,
-    "id2": 9,
+    "id1": "blizzard",
+    "id2": "concussiveattacks",
     "interaction": "Blizzard applies the Concussive Attacks debuff."
   },
   {
-    "id1": 7,
-    "id2": 10,
+    "id1": "blizzard",
+    "id2": "darkness",
     "interaction": "Blizzards appear on the minimap."
   },
   {
-    "id1": 7,
-    "id2": 16,
+    "id1": "blizzard",
+    "id2": "fear",
     "interaction": "Blizzard can apply the Fear effect."
   },
   {
-    "id1": 7,
-    "id2": 18,
+    "id1": "blizzard",
+    "id2": "giftexchange",
     "interaction": "Blizzards can capture gifts."
   },
   {
-    "id1": 7,
-    "id2": 25,
+    "id1": "blizzard",
+    "id2": "laserdrill",
     "interaction": "Blizzards do not provide vision for the Laser Drill."
   },
   {
-    "id1": 7,
-    "id2": 62,
+    "id1": "blizzard",
+    "id2": "wemoveunseen",
     "interaction": "Blizzards are not cloaked."
   },
   {
-    "id1": 8,
-    "id2": 32,
+    "id1": "chaosstudios",
+    "id2": "mineralshields",
     "interaction": "Mineral Shields will always spawn on all mineral patches."
   },
   {
-    "id1": 8,
-    "id2": 50,
+    "id1": "chaosstudios",
+    "id2": "slimpickings",
     "interaction": "Mineral patches will have their total mineral count permanently reduced, even after Slim Pickings  cycles out."
   },
   {
-    "id1": 8,
-    "id2": 60,
+    "id1": "chaosstudios",
+    "id2": "voidrifts",
     "interaction": "Void Rifts will spawn 2:20 after they are activated, meaning only two spawns will occur."
   },
   {
-    "id1": 9,
-    "id2": 13,
+    "id1": "concussiveattacks",
+    "id2": "eminentdomain",
     "interaction": "Turrets captured by Amon apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 17,
+    "id1": "concussiveattacks",
+    "id2": "fireworks",
     "interaction": "Fireworks apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 18,
+    "id1": "concussiveattacks",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 19,
+    "id1": "concussiveattacks",
+    "id2": "goingnuclear",
     "interaction": "Nukes apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 21,
+    "id1": "concussiveattacks",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 23,
+    "id1": "concussiveattacks",
+    "id2": "justdie",
     "interaction": "Respawned units apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 24,
+    "id1": "concussiveattacks",
+    "id2": "killbots",
     "interaction": "Kill Bots apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 25,
+    "id1": "concussiveattacks",
+    "id2": "laserdrill",
     "interaction": "Laser Drill applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 26,
+    "id1": "concussiveattacks",
+    "id2": "lavaburst",
     "interaction": "Lava Burst applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 30,
+    "id1": "concussiveattacks",
+    "id2": "magnificent",
     "interaction": "Mines apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 33,
+    "id1": "concussiveattacks",
+    "id2": "minesweeper",
     "interaction": "Mines apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 34,
+    "id1": "concussiveattacks",
+    "id2": "missilecommand",
     "interaction": "Missiles apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 36,
+    "id1": "concussiveattacks",
+    "id2": "mutuallyassureddestruction",
     "interaction": "Hybrid Nukes apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 38,
+    "id1": "concussiveattacks",
+    "id2": "orbitalstrike",
     "interaction": "Orbital Strikes apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 39,
+    "id1": "concussiveattacks",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 40,
+    "id1": "concussiveattacks",
+    "id2": "photonoverload",
     "interaction": "Photon Overload applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 42,
+    "id1": "concussiveattacks",
+    "id2": "poweroverwhelming",
     "interaction": "Damaging skills will apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 44,
+    "id1": "concussiveattacks",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 46,
+    "id1": "concussiveattacks",
+    "id2": "scorchedearth",
     "interaction": "Scorched Earth applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 47,
+    "id1": "concussiveattacks",
+    "id2": "selfdestruction",
     "interaction": "Self Destruction applies the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 54,
+    "id1": "concussiveattacks",
+    "id2": "transmutation",
     "interaction": "Transmuted units apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 55,
+    "id1": "concussiveattacks",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 56,
+    "id1": "concussiveattacks",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 57,
+    "id1": "concussiveattacks",
+    "id2": "twister",
     "interaction": "Twisters apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 59,
+    "id1": "concussiveattacks",
+    "id2": "voidreanimators",
     "interaction": "Resurrected units apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 60,
+    "id1": "concussiveattacks",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 61,
+    "id1": "concussiveattacks",
+    "id2": "walkinginfested",
     "interaction": "Infested apply the Concussive Attacks debuff."
   },
   {
-    "id1": 9,
-    "id2": 63,
+    "id1": "concussiveattacks",
+    "id2": "boombots",
     "interaction": "Boom Bots apply the Concussive Attacks debuff."
   },
   {
-    "id1": 10,
-    "id2": 18,
+    "id1": "darkness",
+    "id2": "giftexchange",
     "interaction": "Gifts do not appear on the minimap. Kill Bots gifted to Amon do not appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 24,
+    "id1": "darkness",
+    "id2": "killbots",
     "interaction": "Kill Bots do not appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 25,
+    "id1": "darkness",
+    "id2": "laserdrill",
     "interaction": "The Laser Drill will be marked on the minimap when it attacks you."
   },
   {
-    "id1": 10,
-    "id2": 30,
+    "id1": "darkness",
+    "id2": "magnificent",
     "interaction": "Mag-mines appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 34,
+    "id1": "darkness",
+    "id2": "missilecommand",
     "interaction": "Missiles do not appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 43,
+    "id1": "darkness",
+    "id2": "propagators",
     "interaction": "Propagators do not appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 44,
+    "id1": "darkness",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam appears as a red dot on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 56,
+    "id1": "darkness",
+    "id2": "turkeyshoot",
     "interaction": "The Turking does not appear on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 60,
+    "id1": "darkness",
+    "id2": "voidrifts",
     "interaction": "Void Rifts are marked on the minimap."
   },
   {
-    "id1": 10,
-    "id2": 63,
+    "id1": "darkness",
+    "id2": "boombots",
     "interaction": "Boom Bots do not appear on the minimap."
   },
   {
-    "id1": 11,
-    "id2": 13,
+    "id1": "diffusion",
+    "id2": "eminentdomain",
     "interaction": "Turrets can be captured by Amon if they deal too much damage to themselves."
   },
   {
-    "id1": 11,
-    "id2": 16,
+    "id1": "diffusion",
+    "id2": "fear",
     "interaction": "Damage dealt by Diffusion can trigger Fear."
   },
   {
-    "id1": 11,
-    "id2": 18,
+    "id1": "diffusion",
+    "id2": "giftexchange",
     "interaction": "Diffusion applies to all units spawned from Gift Exchange."
   },
   {
-    "id1": 11,
-    "id2": 27,
+    "id1": "diffusion",
+    "id2": "lifeleech",
     "interaction": "Damage dealt by Diffusion counts as Life Leech for the unit attacked."
   },
   {
-    "id1": 11,
-    "id2": 41,
+    "id1": "diffusion",
+    "id2": "polarity",
     "interaction": "Diffusion damages all units regardless of their Polarity."
   },
   {
-    "id1": 11,
-    "id2": 54,
+    "id1": "diffusion",
+    "id2": "transmutation",
     "interaction": "Damage dealt by Diffusion can trigger Transmutation on enemy units."
   },
   {
-    "id1": 12,
-    "id2": 13,
+    "id1": "doubleedged",
+    "id2": "eminentdomain",
     "interaction": "Turrets can be captured by Amon if they deal too much damage to themselves."
   },
   {
-    "id1": 12,
-    "id2": 16,
+    "id1": "doubleedged",
+    "id2": "fear",
     "interaction": "Damage dealt by Double Edged does not trigger Fear."
   },
   {
-    "id1": 12,
-    "id2": 27,
+    "id1": "doubleedged",
+    "id2": "lifeleech",
     "interaction": "Damage dealt by Double Edged does not trigger Life Leech."
   },
   {
-    "id1": 12,
-    "id2": 54,
+    "id1": "doubleedged",
+    "id2": "transmutation",
     "interaction": "Damage dealt by Double Edged does not trigger Transmutation."
   },
   {
-    "id1": 13,
-    "id2": 16,
+    "id1": "eminentdomain",
+    "id2": "fear",
     "interaction": "Turrets captured by Amon can apply the Fear effect."
   },
   {
-    "id1": 13,
-    "id2": 24,
+    "id1": "eminentdomain",
+    "id2": "killbots",
     "interaction": "Kill Bots spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 13,
-    "id2": 27,
+    "id1": "eminentdomain",
+    "id2": "lifeleech",
     "interaction": "Turrets captured by Amon have Life Leech."
   },
   {
-    "id1": 13,
-    "id2": 28,
+    "id1": "eminentdomain",
+    "id2": "longrange",
     "interaction": "Structures captured by Amon get the Long Range buff."
   },
   {
-    "id1": 13,
-    "id2": 39,
+    "id1": "eminentdomain",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 13,
-    "id2": 41,
+    "id1": "eminentdomain",
+    "id2": "polarity",
     "interaction": "Structures captured by Amon get Polarity."
   },
   {
-    "id1": 13,
-    "id2": 43,
+    "id1": "eminentdomain",
+    "id2": "propagators",
     "interaction": "Structures hit by Propagators change to a Propagator and do not get converted. Propagators spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 13,
-    "id2": 54,
+    "id1": "eminentdomain",
+    "id2": "transmutation",
     "interaction": "The attack that kills a player's structure will not cause the enemy unit to Transmute."
   },
   {
-    "id1": 13,
-    "id2": 55,
+    "id1": "eminentdomain",
+    "id2": "trickortreat",
     "interaction": "Civilians spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 13,
-    "id2": 56,
+    "id1": "eminentdomain",
+    "id2": "turkeyshoot",
     "interaction": "Structures destroyed by Turkeys will be converted."
   },
   {
-    "id1": 13,
-    "id2": 59,
+    "id1": "eminentdomain",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 13,
-    "id2": 63,
+    "id1": "eminentdomain",
+    "id2": "boombots",
     "interaction": "Boom Bots spawn out of structures converted by Eminent Domain."
   },
   {
-    "id1": 14,
-    "id2": 18,
+    "id1": "evasivemaneuvers",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange get the Evasive Manuevers buff."
   },
   {
-    "id1": 14,
-    "id2": 21,
+    "id1": "evasivemaneuvers",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes do not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 23,
+    "id1": "evasivemaneuvers",
+    "id2": "justdie",
     "interaction": "Respawned units get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 33,
+    "id1": "evasivemaneuvers",
+    "id2": "minesweeper",
     "interaction": "Mines do not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 34,
+    "id1": "evasivemaneuvers",
+    "id2": "missilecommand",
     "interaction": "Missiles do not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 39,
+    "id1": "evasivemaneuvers",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 41,
+    "id1": "evasivemaneuvers",
+    "id2": "polarity",
     "interaction": "Damage blocked by Polarity still triggers Evasive Maneuvers."
   },
   {
-    "id1": 14,
-    "id2": 43,
+    "id1": "evasivemaneuvers",
+    "id2": "propagators",
     "interaction": "Propagators do not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 54,
+    "id1": "evasivemaneuvers",
+    "id2": "transmutation",
     "interaction": "Transmuted units get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 55,
+    "id1": "evasivemaneuvers",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 56,
+    "id1": "evasivemaneuvers",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not get the Evasive Maneuvers buff. Angry Turkeys get the Evasive Maneuvers buff. The Turking does not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 59,
+    "id1": "evasivemaneuvers",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 60,
+    "id1": "evasivemaneuvers",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts get the Evasive Maneuvers buff."
   },
   {
-    "id1": 14,
-    "id2": 61,
+    "id1": "evasivemaneuvers",
+    "id2": "walkinginfested",
     "interaction": "Infested get the Evasive Maneuvers buff."
   },
   {
-    "id1": 15,
-    "id2": 18,
+    "id1": "fatalattraction",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 21,
+    "id1": "fatalattraction",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 23,
+    "id1": "fatalattraction",
+    "id2": "justdie",
     "interaction": "Units do not trigger Fatal Attraction when taking fatal damage and respawning."
   },
   {
-    "id1": 15,
-    "id2": 24,
+    "id1": "fatalattraction",
+    "id2": "killbots",
     "interaction": "Kill Bots trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 30,
+    "id1": "fatalattraction",
+    "id2": "magnificent",
     "interaction": "Mag-mines trigger Fatal Attraction when they detonate."
   },
   {
-    "id1": 15,
-    "id2": 32,
+    "id1": "fatalattraction",
+    "id2": "mineralshields",
     "interaction": "Mineral Shields trigger Fatal Attraction when destroyed or when they expire.\r\n."
   },
   {
-    "id1": 15,
-    "id2": 33,
+    "id1": "fatalattraction",
+    "id2": "minesweeper",
     "interaction": "Mines trigger Fatal Attraction when they are destroyed."
   },
   {
-    "id1": 15,
-    "id2": 34,
+    "id1": "fatalattraction",
+    "id2": "missilecommand",
     "interaction": "Missiles do not trigger Fatal Attraction when destroyed."
   },
   {
-    "id1": 15,
-    "id2": 36,
+    "id1": "fatalattraction",
+    "id2": "mutuallyassureddestruction",
     "interaction": "Hybrids will only trigger Mutually Assured Destruction"
   },
   {
-    "id1": 15,
-    "id2": 39,
+    "id1": "fatalattraction",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 43,
+    "id1": "fatalattraction",
+    "id2": "propagators",
     "interaction": "Propagators trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 54,
+    "id1": "fatalattraction",
+    "id2": "transmutation",
     "interaction": "Transmuted units trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 55,
+    "id1": "fatalattraction",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians  trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 56,
+    "id1": "fatalattraction",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 59,
+    "id1": "fatalattraction",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 60,
+    "id1": "fatalattraction",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 61,
+    "id1": "fatalattraction",
+    "id2": "walkinginfested",
     "interaction": "Infested trigger Fatal Attraction when they die."
   },
   {
-    "id1": 15,
-    "id2": 63,
+    "id1": "fatalattraction",
+    "id2": "boombots",
     "interaction": "Boom Bots trigger Fatal Attraction when they die."
   },
   {
-    "id1": 16,
-    "id2": 17,
+    "id1": "fear",
+    "id2": "fireworks",
     "interaction": "Fireworks can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 18,
+    "id1": "fear",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 19,
+    "id1": "fear",
+    "id2": "goingnuclear",
     "interaction": "Nukes can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 21,
+    "id1": "fear",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 23,
+    "id1": "fear",
+    "id2": "justdie",
     "interaction": "Respawned units can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 24,
+    "id1": "fear",
+    "id2": "killbots",
     "interaction": "Kill Bots can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 25,
+    "id1": "fear",
+    "id2": "laserdrill",
     "interaction": "Laser Drill can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 26,
+    "id1": "fear",
+    "id2": "lavaburst",
     "interaction": "Lava Burst can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 30,
+    "id1": "fear",
+    "id2": "magnificent",
     "interaction": "Mines can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 33,
+    "id1": "fear",
+    "id2": "minesweeper",
     "interaction": "Mines can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 36,
+    "id1": "fear",
+    "id2": "mutuallyassureddestruction",
     "interaction": "Hybrid Nukes can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 38,
+    "id1": "fear",
+    "id2": "orbitalstrike",
     "interaction": "Orbital Strikes can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 39,
+    "id1": "fear",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 40,
+    "id1": "fear",
+    "id2": "photonoverload",
     "interaction": "Photon Overload can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 44,
+    "id1": "fear",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 46,
+    "id1": "fear",
+    "id2": "scorchedearth",
     "interaction": "Scorched Earth can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 47,
+    "id1": "fear",
+    "id2": "selfdestruction",
     "interaction": "Self Destruction can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 54,
+    "id1": "fear",
+    "id2": "transmutation",
     "interaction": "Transmuted units can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 55,
+    "id1": "fear",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 56,
+    "id1": "fear",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 57,
+    "id1": "fear",
+    "id2": "twister",
     "interaction": "Twisters can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 59,
+    "id1": "fear",
+    "id2": "voidreanimators",
     "interaction": "Resurrected units can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 60,
+    "id1": "fear",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 61,
+    "id1": "fear",
+    "id2": "walkinginfested",
     "interaction": "Infested can apply the Fear effect."
   },
   {
-    "id1": 16,
-    "id2": 63,
+    "id1": "fear",
+    "id2": "boombots",
     "interaction": "Boom Bots do not apply the Fear effect."
   },
   {
-    "id1": 17,
-    "id2": 18,
+    "id1": "fireworks",
+    "id2": "giftexchange",
     "interaction": "Units spawned from Gift Exchange launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 21,
+    "id1": "fireworks",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes do not launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 24,
+    "id1": "fireworks",
+    "id2": "killbots",
     "interaction": "Kill Bots launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 30,
+    "id1": "fireworks",
+    "id2": "magnificent",
     "interaction": "Mines do not launch Fireworks when they explode."
   },
   {
-    "id1": 17,
-    "id2": 33,
+    "id1": "fireworks",
+    "id2": "minesweeper",
     "interaction": "Mines do not launch Fireworks when they are destroyed."
   },
   {
-    "id1": 17,
-    "id2": 34,
+    "id1": "fireworks",
+    "id2": "missilecommand",
     "interaction": "Missiles do not launch Fireworks when they are destroyed."
   },
   {
-    "id1": 17,
-    "id2": 39,
+    "id1": "fireworks",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 43,
+    "id1": "fireworks",
+    "id2": "propagators",
     "interaction": "Propagators do not launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 55,
+    "id1": "fireworks",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 56,
+    "id1": "fireworks",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not launch Fireworks when they die. The Turking launches Fireworks when it dies."
   },
   {
-    "id1": 17,
-    "id2": 59,
+    "id1": "fireworks",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 60,
+    "id1": "fireworks",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 61,
+    "id1": "fireworks",
+    "id2": "walkinginfested",
     "interaction": "Infested do not launch Fireworks when they die."
   },
   {
-    "id1": 17,
-    "id2": 63,
+    "id1": "fireworks",
+    "id2": "boombots",
     "interaction": "Boom Bots launch Fireworks when they die."
   },
   {
-    "id1": 18,
-    "id2": 20,
+    "id1": "giftexchange",
+    "id2": "hardenedwill",
     "interaction": "Units spawned from Gift Exchange can cause Hardened Will to activate. Hybrids and Kill Bots spawned from Gift Exchange can get the Hardened Will buff."
   },
   {
-    "id1": 18,
-    "id2": 21,
+    "id1": "giftexchange",
+    "id2": "heroesfromthestorm",
     "interaction": "Gift spawns do not spawn an Amon Heroes with the capturing attack force. Amon Heroes can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 22,
+    "id1": "giftexchange",
+    "id2": "inspiration",
     "interaction": "Units spawned from Gift Exchange can get the Inspiration buff. Hybrids and Kill Bots spawned from Gift Exchange can provide the Inspiration buff."
   },
   {
-    "id1": 18,
-    "id2": 23,
+    "id1": "giftexchange",
+    "id2": "justdie",
     "interaction": "Units spawned from Gift Exchange respawn when they die."
   },
   {
-    "id1": 18,
-    "id2": 24,
+    "id1": "giftexchange",
+    "id2": "killbots",
     "interaction": "Kill Bots can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 25,
+    "id1": "giftexchange",
+    "id2": "laserdrill",
     "interaction": "Gifts do not provide vision for the Laser Drill."
   },
   {
-    "id1": 18,
-    "id2": 26,
+    "id1": "giftexchange",
+    "id2": "lavaburst",
     "interaction": "Lava Bursts cannot capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 27,
+    "id1": "giftexchange",
+    "id2": "lifeleech",
     "interaction": "Units spawned from Gift Exchange have Life Leech."
   },
   {
-    "id1": 18,
-    "id2": 28,
+    "id1": "giftexchange",
+    "id2": "longrange",
     "interaction": "Units spawned from Gift Exchange get the Long Range buff."
   },
   {
-    "id1": 18,
-    "id2": 30,
+    "id1": "giftexchange",
+    "id2": "magnificent",
     "interaction": "Mag-mines can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 33,
+    "id1": "giftexchange",
+    "id2": "minesweeper",
     "interaction": "Mines can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 34,
+    "id1": "giftexchange",
+    "id2": "missilecommand",
     "interaction": "Missiles can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 35,
+    "id1": "giftexchange",
+    "id2": "momentofsilence",
     "interaction": "Hybrids spawned from Gift Exchange trigger Moment of Silence when they die."
   },
   {
-    "id1": 18,
-    "id2": 36,
+    "id1": "giftexchange",
+    "id2": "mutuallyassureddestruction",
     "interaction": "Hybrids spawned from Gift Exchange detonate Hybrid Nukes when they die."
   },
   {
-    "id1": 18,
-    "id2": 37,
+    "id1": "giftexchange",
+    "id2": "naughtylist",
     "interaction": "Units spawned from Gift Exchange kills increase the Naughty List count."
   },
   {
-    "id1": 18,
-    "id2": 39,
+    "id1": "giftexchange",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 41,
+    "id1": "giftexchange",
+    "id2": "polarity",
     "interaction": "Units spawned from Gift Exchange all have Polarity applied to them."
   },
   {
-    "id1": 18,
-    "id2": 42,
+    "id1": "giftexchange",
+    "id2": "poweroverwhelming",
     "interaction": "Units spawned from Gift Exchange can cast abilities."
   },
   {
-    "id1": 18,
-    "id2": 43,
+    "id1": "giftexchange",
+    "id2": "propagators",
     "interaction": "Propagators can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 44,
+    "id1": "giftexchange",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 46,
+    "id1": "giftexchange",
+    "id2": "scorchedearth",
     "interaction": "Units spawned from Gift Exchange set the ground on fire when they die."
   },
   {
-    "id1": 18,
-    "id2": 47,
+    "id1": "giftexchange",
+    "id2": "selfdestruction",
     "interaction": "Units spawned from Gift Exchange create an explosion when they die."
   },
   {
-    "id1": 18,
-    "id2": 51,
+    "id1": "giftexchange",
+    "id2": "speedfreaks",
     "interaction": "Units spawned from Gift Exchange move faster with Speed Freaks."
   },
   {
-    "id1": 18,
-    "id2": 52,
+    "id1": "giftexchange",
+    "id2": "temporalfield",
     "interaction": "Temporal Fields cannot capture gifts. Units caught in a Temporal Field can still capture Gifts."
   },
   {
-    "id1": 18,
-    "id2": 53,
+    "id1": "giftexchange",
+    "id2": "timewarp",
     "interaction": "Time Warps cannot capture gifts. Units caught in a Time Warp can still capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 54,
+    "id1": "giftexchange",
+    "id2": "transmutation",
     "interaction": "Units spawned from Gift Exchange can Transmute."
   },
   {
-    "id1": 18,
-    "id2": 56,
+    "id1": "giftexchange",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys cannot capture gifts. Angry Turkeys can capture gifts. The Turking can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 57,
+    "id1": "giftexchange",
+    "id2": "twister",
     "interaction": "Twisters can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 59,
+    "id1": "giftexchange",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can capture gifts. Void Reanimators can resurrect units spawned from Gift Exchange. Void Reanimators do not resurrect Kill Bots."
   },
   {
-    "id1": 18,
-    "id2": 60,
+    "id1": "giftexchange",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can capture gifts."
   },
   {
-    "id1": 18,
-    "id2": 61,
+    "id1": "giftexchange",
+    "id2": "walkinginfested",
     "interaction": "Infested can capture gifts. Units spawned from Gift Exchange spawn Infested when they die."
   },
   {
-    "id1": 18,
-    "id2": 62,
+    "id1": "giftexchange",
+    "id2": "wemoveunseen",
     "interaction": "Units spawned from Gift Exchange are cloaked."
   },
   {
-    "id1": 18,
-    "id2": 63,
+    "id1": "giftexchange",
+    "id2": "boombots",
     "interaction": "Boom Bots do not capture gifts."
   },
   {
-    "id1": 19,
-    "id2": 25,
+    "id1": "goingnuclear",
+    "id2": "laserdrill",
     "interaction": "The Laser Drill has vision of the area for a short time after the nuke hits."
   },
   {
-    "id1": 20,
-    "id2": 21,
+    "id1": "hardenedwill",
+    "id2": "heroesfromthestorm",
     "interaction": "Amon Heroes can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 24,
+    "id1": "hardenedwill",
+    "id2": "killbots",
     "interaction": "Kill Bots can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 30,
+    "id1": "hardenedwill",
+    "id2": "magnificent",
     "interaction": "Mag-mines do not cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 33,
+    "id1": "hardenedwill",
+    "id2": "minesweeper",
     "interaction": "Mines cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 34,
+    "id1": "hardenedwill",
+    "id2": "missilecommand",
     "interaction": "Missiles cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 39,
+    "id1": "hardenedwill",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 43,
+    "id1": "hardenedwill",
+    "id2": "propagators",
     "interaction": "Propagators can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 44,
+    "id1": "hardenedwill",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beam does not cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 54,
+    "id1": "hardenedwill",
+    "id2": "transmutation",
     "interaction": "Transmuted units cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 55,
+    "id1": "hardenedwill",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians can cause Hardened Will to activate. Hybrids spawned from Civilians can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 56,
+    "id1": "hardenedwill",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not cause Hardened Will to activate. Angry Turkeys cause Hardened Will to activate. The Turking can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 60,
+    "id1": "hardenedwill",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts cause Hardened Will to activate. Hybrids spawned from Void Rifts can get the Hardened Will buff."
   },
   {
-    "id1": 20,
-    "id2": 61,
+    "id1": "hardenedwill",
+    "id2": "walkinginfested",
     "interaction": "Infested cause Hardened Will to activate."
   },
   {
-    "id1": 20,
-    "id2": 63,
+    "id1": "hardenedwill",
+    "id2": "boombots",
     "interaction": "Boom Bots do not get the Hardened Will buff."
   },
   {
-    "id1": 21,
-    "id2": 22,
+    "id1": "heroesfromthestorm",
+    "id2": "inspiration",
     "interaction": "Amon Heroes can provide the Inspiration buff."
   },
   {
-    "id1": 21,
-    "id2": 23,
+    "id1": "heroesfromthestorm",
+    "id2": "justdie",
     "interaction": "Amon Heroes respawn when they die."
   },
   {
-    "id1": 21,
-    "id2": 27,
+    "id1": "heroesfromthestorm",
+    "id2": "lifeleech",
     "interaction": "Amon Heroes have Life Leech."
   },
   {
-    "id1": 21,
-    "id2": 28,
+    "id1": "heroesfromthestorm",
+    "id2": "longrange",
     "interaction": "Amon Heroes do not get the Long Range buff."
   },
   {
-    "id1": 21,
-    "id2": 35,
+    "id1": "heroesfromthestorm",
+    "id2": "momentofsilence",
     "interaction": "Amon Heroes trigger Moment of Silence when they die."
   },
   {
-    "id1": 21,
-    "id2": 37,
+    "id1": "heroesfromthestorm",
+    "id2": "naughtylist",
     "interaction": "Amon Hero kills increase the Naughty List count."
   },
   {
-    "id1": 21,
-    "id2": 40,
+    "id1": "heroesfromthestorm",
+    "id2": "photonoverload",
     "interaction": "Amon's Karax's spawned structures will have Photon Overload applied when damaged."
   },
   {
-    "id1": 21,
-    "id2": 41,
+    "id1": "heroesfromthestorm",
+    "id2": "polarity",
     "interaction": "Amon Heroes all have Polarity applied to them."
   },
   {
-    "id1": 21,
-    "id2": 42,
+    "id1": "heroesfromthestorm",
+    "id2": "poweroverwhelming",
     "interaction": "Amon Heroes can cast abilities other than the ones they already have."
   },
   {
-    "id1": 21,
-    "id2": 46,
+    "id1": "heroesfromthestorm",
+    "id2": "scorchedearth",
     "interaction": "Amon Heroes set the ground on fire when they die."
   },
   {
-    "id1": 21,
-    "id2": 47,
+    "id1": "heroesfromthestorm",
+    "id2": "selfdestruction",
     "interaction": "Amon Heroes create an explosion when they die."
   },
   {
-    "id1": 21,
-    "id2": 51,
+    "id1": "heroesfromthestorm",
+    "id2": "speedfreaks",
     "interaction": "Amon Heroes move faster with Speed Freaks."
   },
   {
-    "id1": 21,
-    "id2": 54,
+    "id1": "heroesfromthestorm",
+    "id2": "transmutation",
     "interaction": "Amon Heroes do not Transmute after killing a unit."
   },
   {
-    "id1": 21,
-    "id2": 59,
+    "id1": "heroesfromthestorm",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not resurrect Amon Heroes."
   },
   {
-    "id1": 21,
-    "id2": 61,
+    "id1": "heroesfromthestorm",
+    "id2": "walkinginfested",
     "interaction": "Amon Heroes spawn Infested when they die."
   },
   {
-    "id1": 21,
-    "id2": 62,
+    "id1": "heroesfromthestorm",
+    "id2": "wemoveunseen",
     "interaction": "Amon Heroes are cloaked."
   },
   {
-    "id1": 22,
-    "id2": 24,
+    "id1": "inspiration",
+    "id2": "killbots",
     "interaction": "Kill Bots can provide the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 39,
+    "id1": "inspiration",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations can get the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 43,
+    "id1": "inspiration",
+    "id2": "propagators",
     "interaction": "Propagators can provide the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 54,
+    "id1": "inspiration",
+    "id2": "transmutation",
     "interaction": "Transmuted units can get the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 55,
+    "id1": "inspiration",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians can get the Inspiration buff. Hybrids spawned from Civilians can provide the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 56,
+    "id1": "inspiration",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not get the Inspiration buff. Angry Turkeys get the Inspiration buff. The Turking can provide the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 59,
+    "id1": "inspiration",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can get the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 60,
+    "id1": "inspiration",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can get the Inspiration buff. Hybrids spawned from Void Rifts can provide the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 61,
+    "id1": "inspiration",
+    "id2": "walkinginfested",
     "interaction": "Infested can get the Inspiration buff."
   },
   {
-    "id1": 22,
-    "id2": 63,
+    "id1": "inspiration",
+    "id2": "boombots",
     "interaction": "Boom Bots do not provide the Inspiration buff."
   },
   {
-    "id1": 23,
-    "id2": 24,
+    "id1": "justdie",
+    "id2": "killbots",
     "interaction": "Kill Bots do not respawn when they self-destruct. They will respawn if killed by Abathur's Toxic Nests."
   },
   {
-    "id1": 23,
-    "id2": 27,
+    "id1": "justdie",
+    "id2": "lifeleech",
     "interaction": "Respawned units have Life Leech."
   },
   {
-    "id1": 23,
-    "id2": 30,
+    "id1": "justdie",
+    "id2": "magnificent",
     "interaction": "Mag-mines do not respawn when they explode."
   },
   {
-    "id1": 23,
-    "id2": 33,
+    "id1": "justdie",
+    "id2": "minesweeper",
     "interaction": "Mines respawn when they are destroyed."
   },
   {
-    "id1": 23,
-    "id2": 34,
+    "id1": "justdie",
+    "id2": "missilecommand",
     "interaction": "Missiles respawn when destroyed."
   },
   {
-    "id1": 23,
-    "id2": 35,
+    "id1": "justdie",
+    "id2": "momentofsilence",
     "interaction": "Units do not trigger Moment of Silence when taking fatal damage and respawning."
   },
   {
-    "id1": 23,
-    "id2": 36,
+    "id1": "justdie",
+    "id2": "mutuallyassureddestruction",
     "interaction": "Hybrids do not detonate Hybrid Nukes when taking fatal damage and respawning."
   },
   {
-    "id1": 23,
-    "id2": 37,
+    "id1": "justdie",
+    "id2": "naughtylist",
     "interaction": "Units do not increase the Naughty List count when taking fatal damage and respawning."
   },
   {
-    "id1": 23,
-    "id2": 39,
+    "id1": "justdie",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations respawn when they die."
   },
   {
-    "id1": 23,
-    "id2": 41,
+    "id1": "justdie",
+    "id2": "polarity",
     "interaction": "Polarity reverses after a unit respawns."
   },
   {
-    "id1": 23,
-    "id2": 43,
+    "id1": "justdie",
+    "id2": "propagators",
     "interaction": "Propagators respawn when they die. When a Propagator Propagates a unit, the new Propagator will have the Just Die! buff applied to it too and will need to be killed twice."
   },
   {
-    "id1": 23,
-    "id2": 46,
+    "id1": "justdie",
+    "id2": "scorchedearth",
     "interaction": "Units do not set the ground of fire when taking fatal damage and respawning."
   },
   {
-    "id1": 23,
-    "id2": 47,
+    "id1": "justdie",
+    "id2": "selfdestruction",
     "interaction": "Units do set the ground on fire when taking fatal damage and respawning."
   },
   {
-    "id1": 23,
-    "id2": 51,
+    "id1": "justdie",
+    "id2": "speedfreaks",
     "interaction": "Respawned units keep moving faster with Speed Freaks."
   },
   {
-    "id1": 23,
-    "id2": 54,
+    "id1": "justdie",
+    "id2": "transmutation",
     "interaction": "Transmutated units have their Just Die stacks reset, allowing them to respawn again."
   },
   {
-    "id1": 23,
-    "id2": 55,
+    "id1": "justdie",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians respawn when they die."
   },
   {
-    "id1": 23,
-    "id2": 56,
+    "id1": "justdie",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not respawn when they die. The Turking respawns when it dies."
   },
   {
-    "id1": 23,
-    "id2": 59,
+    "id1": "justdie",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators respawn when they die. Resurrected units respawn when they die."
   },
   {
-    "id1": 23,
-    "id2": 60,
+    "id1": "justdie",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts respawn when they die."
   },
   {
-    "id1": 23,
-    "id2": 61,
+    "id1": "justdie",
+    "id2": "walkinginfested",
     "interaction": "Infested respawn when they die."
   },
   {
-    "id1": 23,
-    "id2": 62,
+    "id1": "justdie",
+    "id2": "wemoveunseen",
     "interaction": "Respawned units are cloaked."
   },
   {
-    "id1": 23,
-    "id2": 63,
+    "id1": "justdie",
+    "id2": "boombots",
     "interaction": "Boom Bots do not respawn when they self-destruct."
   },
   {
-    "id1": 24,
-    "id2": 25,
+    "id1": "killbots",
+    "id2": "laserdrill",
     "interaction": "Kill Bots provide vision for the Laser Drill.\r\nKill Bots do not spawn from the Laser Drill."
   },
   {
-    "id1": 24,
-    "id2": 28,
+    "id1": "killbots",
+    "id2": "longrange",
     "interaction": "Kill Bots get the Long Range buff."
   },
   {
-    "id1": 24,
-    "id2": 35,
+    "id1": "killbots",
+    "id2": "momentofsilence",
     "interaction": "Kill Bots trigger Moment of Silence when they die."
   },
   {
-    "id1": 24,
-    "id2": 42,
+    "id1": "killbots",
+    "id2": "poweroverwhelming",
     "interaction": "Kill Bots can cast abilities. Kill bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
-    "id1": 24,
-    "id2": 46,
+    "id1": "killbots",
+    "id2": "scorchedearth",
     "interaction": "Kill Bots set the ground on fire when they die."
   },
   {
-    "id1": 24,
-    "id2": 47,
+    "id1": "killbots",
+    "id2": "selfdestruction",
     "interaction": "Kill Bots create an explosion when they die."
   },
   {
-    "id1": 24,
-    "id2": 51,
+    "id1": "killbots",
+    "id2": "speedfreaks",
     "interaction": "Kill Bots move faster with Speed Freaks."
   },
   {
-    "id1": 24,
-    "id2": 54,
+    "id1": "killbots",
+    "id2": "transmutation",
     "interaction": "Kill Bots do not Transmute when dealing damage or killing units."
   },
   {
-    "id1": 24,
-    "id2": 59,
+    "id1": "killbots",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not resurrect Kill Bots."
   },
   {
-    "id1": 24,
-    "id2": 60,
+    "id1": "killbots",
+    "id2": "voidrifts",
     "interaction": "Kill Bots do not spawn from Void Rifts."
   },
   {
-    "id1": 24,
-    "id2": 61,
+    "id1": "killbots",
+    "id2": "walkinginfested",
     "interaction": "Kill Bots spawn Infested when they die."
   },
   {
-    "id1": 24,
-    "id2": 62,
+    "id1": "killbots",
+    "id2": "wemoveunseen",
     "interaction": "Kill Bots are cloaked."
   },
   {
-    "id1": 25,
-    "id2": 26,
+    "id1": "laserdrill",
+    "id2": "lavaburst",
     "interaction": "Lava Bursts do not provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 27,
+    "id1": "laserdrill",
+    "id2": "lifeleech",
     "interaction": "Laser Drill has Life Leech."
   },
   {
-    "id1": 25,
-    "id2": 30,
+    "id1": "laserdrill",
+    "id2": "magnificent",
     "interaction": "Mag-mines provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 32,
+    "id1": "laserdrill",
+    "id2": "mineralshields",
     "interaction": "Mineral Shields provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 33,
+    "id1": "laserdrill",
+    "id2": "minesweeper",
     "interaction": "Mines provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 34,
+    "id1": "laserdrill",
+    "id2": "missilecommand",
     "interaction": "Missiles do not provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 39,
+    "id1": "laserdrill",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations provide vision for the Laser Drill.\r\nInfested and Aberrations do not spawn from the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 40,
+    "id1": "laserdrill",
+    "id2": "photonoverload",
     "interaction": "The Laser Drill does not get Photon Overcharge when damaged."
   },
   {
-    "id1": 25,
-    "id2": 41,
+    "id1": "laserdrill",
+    "id2": "polarity",
     "interaction": "Polarity of the Laser Drill remains fixed, even when the drill respawns after being destroyed."
   },
   {
-    "id1": 25,
-    "id2": 43,
+    "id1": "laserdrill",
+    "id2": "propagators",
     "interaction": "Propagators provide vision for the Laser Drill. Propagators do not spawn from the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 44,
+    "id1": "laserdrill",
+    "id2": "purifierbeam",
     "interaction": "Purifier Beams do not provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 52,
+    "id1": "laserdrill",
+    "id2": "temporalfield",
     "interaction": "The area inside a Temporal Field provides vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 53,
+    "id1": "laserdrill",
+    "id2": "timewarp",
     "interaction": "Time Warps do not provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 54,
+    "id1": "laserdrill",
+    "id2": "transmutation",
     "interaction": "Transmuted units provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 55,
+    "id1": "laserdrill",
+    "id2": "trickortreat",
     "interaction": "The Candy Bowl provides vision for the Laser Drill. Units spawned from Civilians provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 56,
+    "id1": "laserdrill",
+    "id2": "turkeyshoot",
     "interaction": "Normal Turkeys do not provide vision for the Laser Drill. Angry Turkeys provide vision for the Laser Drill. The Turking provides vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 57,
+    "id1": "laserdrill",
+    "id2": "twister",
     "interaction": "Twisters do not provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 59,
+    "id1": "laserdrill",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators provide vision for the Laser Drill. Void Reanimators do not spawn from the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 60,
+    "id1": "laserdrill",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 61,
+    "id1": "laserdrill",
+    "id2": "walkinginfested",
     "interaction": "Infested provide vision for the Laser Drill."
   },
   {
-    "id1": 25,
-    "id2": 63,
+    "id1": "laserdrill",
+    "id2": "boombots",
     "interaction": "Boom Bots provide vision for the Laser Drill.\r\nBoom Bots do not spawn from the Laser Drill."
   },
   {
-    "id1": 26,
-    "id2": 62,
+    "id1": "lavaburst",
+    "id2": "wemoveunseen",
     "interaction": "Lava Bursts are not cloaked."
   },
   {
-    "id1": 27,
-    "id2": 39,
+    "id1": "lifeleech",
+    "id2": "outbreak",
     "interaction": "Infested and Aberrations have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 54,
+    "id1": "lifeleech",
+    "id2": "transmutation",
     "interaction": "Transmuted units have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 55,
+    "id1": "lifeleech",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 56,
+    "id1": "lifeleech",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 59,
+    "id1": "lifeleech",
+    "id2": "voidreanimators",
     "interaction": "Resurrected units have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 60,
+    "id1": "lifeleech",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts have Life Leech."
   },
   {
-    "id1": 27,
-    "id2": 61,
+    "id1": "lifeleech",
+    "id2": "walkinginfested",
     "interaction": "Infested have Life Leech."
   },
   {
-    "id1": 28,
-    "id2": 30,
+    "id1": "longrange",
+    "id2": "magnificent",
     "interaction": "Mag-mines do not get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 33,
+    "id1": "longrange",
+    "id2": "minesweeper",
     "interaction": "Mines do not get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 39,
+    "id1": "longrange",
+    "id2": "outbreak",
     "interaction": "Infested Marines get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 40,
+    "id1": "longrange",
+    "id2": "photonoverload",
     "interaction": "Photon Overload gets increased range with Long Range."
   },
   {
-    "id1": 28,
-    "id2": 42,
+    "id1": "longrange",
+    "id2": "poweroverwhelming",
     "interaction": "Ranges of spells does not increase with Long Range."
   },
   {
-    "id1": 28,
-    "id2": 43,
+    "id1": "longrange",
+    "id2": "propagators",
     "interaction": "Propagators do not get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 55,
+    "id1": "longrange",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 56,
+    "id1": "longrange",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not get the Long Range buff."
   },
   {
-    "id1": 28,
-    "id2": 59,
+    "id1": "longrange",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not get increased Resurrection range."
   },
   {
-    "id1": 28,
-    "id2": 60,
+    "id1": "longrange",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts get the Long Range buff."
   },
   {
-    "id1": 30,
-    "id2": 42,
+    "id1": "magnificent",
+    "id2": "poweroverwhelming",
     "interaction": "Mag-mines cannot cast abilities."
   },
   {
-    "id1": 30,
-    "id2": 46,
+    "id1": "magnificent",
+    "id2": "scorchedearth",
     "interaction": "Mag-mines do not set the ground on fire when they explode."
   },
   {
-    "id1": 30,
-    "id2": 47,
+    "id1": "magnificent",
+    "id2": "selfdestruction",
     "interaction": "Mag-mines do not create an explosion when explode."
   },
   {
-    "id1": 30,
-    "id2": 51,
+    "id1": "magnificent",
+    "id2": "speedfreaks",
     "interaction": "Mag-mines do not move faster with Speed Freaks."
   },
   {
-    "id1": 30,
-    "id2": 54,
+    "id1": "magnificent",
+    "id2": "transmutation",
     "interaction": "Mag-mines do not Transmute after killing a unit."
   },
   {
-    "id1": 30,
-    "id2": 59,
+    "id1": "magnificent",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators do not resurrect Mag-mines."
   },
   {
-    "id1": 30,
-    "id2": 61,
+    "id1": "magnificent",
+    "id2": "walkinginfested",
     "interaction": "Mag-mines do not spawn Infested when they detonate."
   },
   {
-    "id1": 30,
-    "id2": 62,
+    "id1": "magnificent",
+    "id2": "wemoveunseen",
     "interaction": "Mag-mines are cloaked."
   },
   {
-    "id1": 32,
-    "id2": 37,
+    "id1": "mineralshields",
+    "id2": "naughtylist",
     "interaction": "Mineral Shield kills increase the Naughty List count."
   },
   {
-    "id1": 32,
-    "id2": 40,
+    "id1": "mineralshields",
+    "id2": "photonoverload",
     "interaction": "Mineral Shields will have Photon Overload applied when damaged."
   },
   {
-    "id1": 32,
-    "id2": 41,
+    "id1": "mineralshields",
+    "id2": "polarity",
     "interaction": "Mineral Shields all have Polarity applied to them."
   },
   {
-    "id1": 33,
-    "id2": 37,
+    "id1": "minesweeper",
+    "id2": "naughtylist",
     "interaction": "Mine kills increase the Naughty List count."
   },
   {
-    "id1": 33,
-    "id2": 41,
+    "id1": "minesweeper",
+    "id2": "polarity",
     "interaction": "Widow Mines and Spider Mines all have Polarity applied to them."
   },
   {
-    "id1": 33,
-    "id2": 42,
+    "id1": "minesweeper",
+    "id2": "poweroverwhelming",
     "interaction": "Widow mines can cast abilities. Spider mines cannot cast abilities."
   },
   {
-    "id1": 33,
-    "id2": 46,
+    "id1": "minesweeper",
+    "id2": "scorchedearth",
     "interaction": "Mines set the ground on fire when they die."
   },
   {
-    "id1": 33,
-    "id2": 47,
+    "id1": "minesweeper",
+    "id2": "selfdestruction",
     "interaction": "Mines set the ground on fire when they are destroyed."
   },
   {
-    "id1": 33,
-    "id2": 51,
+    "id1": "minesweeper",
+    "id2": "speedfreaks",
     "interaction": "Spider mines do not move faster with Speed Freaks."
   },
   {
-    "id1": 33,
-    "id2": 54,
+    "id1": "minesweeper",
+    "id2": "transmutation",
     "interaction": "Widow Mines Transmute after killing a unit."
   },
   {
-    "id1": 33,
-    "id2": 59,
+    "id1": "minesweeper",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators resurrect Widow Mines but not Spider Mines. Widow Mines will move towards player bases after resurrection."
   },
   {
-    "id1": 33,
-    "id2": 61,
+    "id1": "minesweeper",
+    "id2": "walkinginfested",
     "interaction": "Mines spawned Infested when they are destroyed."
   },
   {
-    "id1": 34,
-    "id2": 37,
+    "id1": "missilecommand",
+    "id2": "naughtylist",
     "interaction": "Missile kills do not increase the Naughty List count."
   },
   {
-    "id1": 34,
-    "id2": 41,
+    "id1": "missilecommand",
+    "id2": "polarity",
     "interaction": "Missiles have Polarity applied to them."
   },
   {
-    "id1": 34,
-    "id2": 42,
+    "id1": "missilecommand",
+    "id2": "poweroverwhelming",
     "interaction": "Point Defense Missiles can cast abilities."
   },
   {
-    "id1": 34,
-    "id2": 46,
+    "id1": "missilecommand",
+    "id2": "scorchedearth",
     "interaction": "Missiles set the ground on fire when they are destroyed."
   },
   {
-    "id1": 34,
-    "id2": 47,
+    "id1": "missilecommand",
+    "id2": "selfdestruction",
     "interaction": "Missiles create an explosion when destroyed."
   },
   {
-    "id1": 34,
-    "id2": 51,
+    "id1": "missilecommand",
+    "id2": "speedfreaks",
     "interaction": "Missiles do not move faster with Speed Freaks."
   },
   {
-    "id1": 34,
-    "id2": 59,
+    "id1": "missilecommand",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators cannot resurrect Missiles."
   },
   {
-    "id1": 34,
-    "id2": 61,
+    "id1": "missilecommand",
+    "id2": "walkinginfested",
     "interaction": "Missiles do not spawn Infested when they land on their target. Missiles spawn Infested when destroyed by players."
   },
   {
-    "id1": 34,
-    "id2": 62,
+    "id1": "missilecommand",
+    "id2": "wemoveunseen",
     "interaction": "Missiles are cloaked."
   },
   {
-    "id1": 35,
-    "id2": 43,
+    "id1": "momentofsilence",
+    "id2": "propagators",
     "interaction": "Propagators trigger Moment of Silence when they die."
   },
   {
-    "id1": 35,
-    "id2": 54,
+    "id1": "momentofsilence",
+    "id2": "transmutation",
     "interaction": "Transmuted units which are now Hybrids trigger Moment of Silence when they die."
   },
   {
-    "id1": 35,
-    "id2": 55,
+    "id1": "momentofsilence",
+    "id2": "trickortreat",
     "interaction": "Hybrids spawned from Civilians trigger Moment of Silence when they die."
   },
   {
-    "id1": 35,
-    "id2": 56,
+    "id1": "momentofsilence",
+    "id2": "turkeyshoot",
     "interaction": "The Turking triggers Moment of Silence when it dies."
   },
   {
-    "id1": 35,
-    "id2": 60,
+    "id1": "momentofsilence",
+    "id2": "voidrifts",
     "interaction": "Hybrids spawned from Void Rifts trigger Moment of Silence when they die."
   },
   {
-    "id1": 35,
-    "id2": 63,
+    "id1": "momentofsilence",
+    "id2": "boombots",
     "interaction": "Boom Bots do not trigger Moment of Silence when they die."
   },
   {
-    "id1": 36,
-    "id2": 55,
+    "id1": "mutuallyassureddestruction",
+    "id2": "trickortreat",
     "interaction": "Hybrids spawned from Civilians detonate Hybrid Nukes when they die."
   },
   {
-    "id1": 36,
-    "id2": 60,
+    "id1": "mutuallyassureddestruction",
+    "id2": "voidrifts",
     "interaction": "Hybrids spawned from Void Rifts detonate Hybrid Nukes when they die."
   },
   {
-    "id1": 37,
-    "id2": 39,
+    "id1": "naughtylist",
+    "id2": "outbreak",
     "interaction": "Infested and Aberration kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 43,
+    "id1": "naughtylist",
+    "id2": "propagators",
     "interaction": "Propagator kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 50,
+    "id1": "naughtylist",
+    "id2": "slimpickings",
     "interaction": "Turkey kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 55,
+    "id1": "naughtylist",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 56,
+    "id1": "naughtylist",
+    "id2": "turkeyshoot",
     "interaction": "Turkey kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 59,
+    "id1": "naughtylist",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimator kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 60,
+    "id1": "naughtylist",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts kills increase the Naughty List count."
   },
   {
-    "id1": 37,
-    "id2": 61,
+    "id1": "naughtylist",
+    "id2": "walkinginfested",
     "interaction": "Infested kills increase the Naughty List count."
   },
   {
-    "id1": 39,
-    "id2": 41,
+    "id1": "outbreak",
+    "id2": "polarity",
     "interaction": "Infested and Aberrations all have Polarity applied to them."
   },
   {
-    "id1": 39,
-    "id2": 42,
+    "id1": "outbreak",
+    "id2": "poweroverwhelming",
     "interaction": "Infested and Aberrations can cast abilities. Infested and Aberrations can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
-    "id1": 39,
-    "id2": 46,
+    "id1": "outbreak",
+    "id2": "scorchedearth",
     "interaction": "Infested and Aberrations set the ground on fire when they die."
   },
   {
-    "id1": 39,
-    "id2": 47,
+    "id1": "outbreak",
+    "id2": "selfdestruction",
     "interaction": "Infested and Aberrations create an explosion when they die."
   },
   {
-    "id1": 39,
-    "id2": 51,
+    "id1": "outbreak",
+    "id2": "speedfreaks",
     "interaction": "Infested and Aberrations move faster with Speed Freaks."
   },
   {
-    "id1": 39,
-    "id2": 54,
+    "id1": "outbreak",
+    "id2": "transmutation",
     "interaction": "Infested and Aberrations can transmute."
   },
   {
-    "id1": 39,
-    "id2": 59,
+    "id1": "outbreak",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can resurrect Infested and Aberrations."
   },
   {
-    "id1": 39,
-    "id2": 60,
+    "id1": "outbreak",
+    "id2": "voidrifts",
     "interaction": "Infested and Aberrations do not spawn from Void Rifts."
   },
   {
-    "id1": 39,
-    "id2": 61,
+    "id1": "outbreak",
+    "id2": "walkinginfested",
     "interaction": "Infested and Aberrations do not spawn other infested units when killed."
   },
   {
-    "id1": 39,
-    "id2": 62,
+    "id1": "outbreak",
+    "id2": "wemoveunseen",
     "interaction": "Infested and Aberrations are cloaked."
   },
   {
-    "id1": 40,
-    "id2": 42,
+    "id1": "photonoverload",
+    "id2": "poweroverwhelming",
     "interaction": "Point Defense Drones spawned from Power Overwhelming will gain Photon Overcharge when damaged."
   },
   {
-    "id1": 40,
-    "id2": 60,
+    "id1": "photonoverload",
+    "id2": "voidrifts",
     "interaction": "Void Rifts do not get Photon Overcharge when damaged. "
   },
   {
-    "id1": 41,
-    "id2": 43,
+    "id1": "polarity",
+    "id2": "propagators",
     "interaction": "Propagators that spawn around the map have Polarity applied to them. Propagators spawned from other Propagators do not have any polarity."
   },
   {
-    "id1": 41,
-    "id2": 54,
+    "id1": "polarity",
+    "id2": "transmutation",
     "interaction": "When units Transmute, they can switch Polarities."
   },
   {
-    "id1": 41,
-    "id2": 55,
+    "id1": "polarity",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians all have Polarity applied to them."
   },
   {
-    "id1": 41,
-    "id2": 56,
+    "id1": "polarity",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not have Polarity applied to them. The Turking has Polarity applied to it."
   },
   {
-    "id1": 41,
-    "id2": 59,
+    "id1": "polarity",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators all have Polarity applied to them. Resurrected units may change Polarity after resurrection."
   },
   {
-    "id1": 41,
-    "id2": 60,
+    "id1": "polarity",
+    "id2": "voidrifts",
     "interaction": "Void Rifts and units spawned from Void Rifts all have Polarity applied to them."
   },
   {
-    "id1": 41,
-    "id2": 61,
+    "id1": "polarity",
+    "id2": "walkinginfested",
     "interaction": "Infested all have Polarity applied to them."
   },
   {
-    "id1": 42,
-    "id2": 43,
+    "id1": "poweroverwhelming",
+    "id2": "propagators",
     "interaction": "Propagators can cast abilities. Propagators can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
-    "id1": 42,
-    "id2": 55,
+    "id1": "poweroverwhelming",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians  can cast abilities."
   },
   {
-    "id1": 42,
-    "id2": 56,
+    "id1": "poweroverwhelming",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys cannot cast abilities."
   },
   {
-    "id1": 42,
-    "id2": 59,
+    "id1": "poweroverwhelming",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can cast abilities. Void Reanimators can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
-    "id1": 42,
-    "id2": 60,
+    "id1": "poweroverwhelming",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can cast abilities."
   },
   {
-    "id1": 42,
-    "id2": 61,
+    "id1": "poweroverwhelming",
+    "id2": "walkinginfested",
     "interaction": "Infested can cast abilities."
   },
   {
-    "id1": 42,
-    "id2": 63,
+    "id1": "poweroverwhelming",
+    "id2": "boombots",
     "interaction": "Boom Bots can cast abilities. Boom Bots can spawn out of Point Defense Drones dropped by Power Overwhelming."
   },
   {
-    "id1": 43,
-    "id2": 46,
+    "id1": "propagators",
+    "id2": "scorchedearth",
     "interaction": "Propagators set the ground on fire when they die."
   },
   {
-    "id1": 43,
-    "id2": 47,
+    "id1": "propagators",
+    "id2": "selfdestruction",
     "interaction": "Propagators create an explosion when they die."
   },
   {
-    "id1": 43,
-    "id2": 51,
+    "id1": "propagators",
+    "id2": "speedfreaks",
     "interaction": "Propagators move faster with Speed Freaks."
   },
   {
-    "id1": 43,
-    "id2": 54,
+    "id1": "propagators",
+    "id2": "transmutation",
     "interaction": "Propagators do not Transmute."
   },
   {
-    "id1": 43,
-    "id2": 59,
+    "id1": "propagators",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can resurrect Propagators. Propagators resurrected by Void Reanimators are not marked with an icon on the minimap."
   },
   {
-    "id1": 43,
-    "id2": 60,
+    "id1": "propagators",
+    "id2": "voidrifts",
     "interaction": "Propagators do not spawn from Void Rifts."
   },
   {
-    "id1": 43,
-    "id2": 61,
+    "id1": "propagators",
+    "id2": "walkinginfested",
     "interaction": "Propagators spawn Infested when they die."
   },
   {
-    "id1": 43,
-    "id2": 62,
+    "id1": "propagators",
+    "id2": "wemoveunseen",
     "interaction": "Propagators are cloaked."
   },
   {
-    "id1": 44,
-    "id2": 51,
+    "id1": "purifierbeam",
+    "id2": "speedfreaks",
     "interaction": "Purifier Beam does not move faster with Speed Freaks."
   },
   {
-    "id1": 44,
-    "id2": 62,
+    "id1": "purifierbeam",
+    "id2": "wemoveunseen",
     "interaction": "Purifier Beam is cloaked."
   },
   {
-    "id1": 46,
-    "id2": 55,
+    "id1": "scorchedearth",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians set the ground on fire when they die."
   },
   {
-    "id1": 46,
-    "id2": 56,
+    "id1": "scorchedearth",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys set the ground on fire when they die."
   },
   {
-    "id1": 46,
-    "id2": 59,
+    "id1": "scorchedearth",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators set the ground on fire when they die."
   },
   {
-    "id1": 46,
-    "id2": 60,
+    "id1": "scorchedearth",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts set the ground on fire when they die."
   },
   {
-    "id1": 46,
-    "id2": 61,
+    "id1": "scorchedearth",
+    "id2": "walkinginfested",
     "interaction": "Infested set the ground on fire when they die."
   },
   {
-    "id1": 46,
-    "id2": 63,
+    "id1": "scorchedearth",
+    "id2": "boombots",
     "interaction": "Boom Bots set the ground on fire when they die."
   },
   {
-    "id1": 47,
-    "id2": 55,
+    "id1": "selfdestruction",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians create an explosion when they die."
   },
   {
-    "id1": 47,
-    "id2": 56,
+    "id1": "selfdestruction",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not create an explosion when they die. Angry Turkeys create an explosion when they die. The Turking creates an explosion when it does."
   },
   {
-    "id1": 47,
-    "id2": 59,
+    "id1": "selfdestruction",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators create an explosion when they die."
   },
   {
-    "id1": 47,
-    "id2": 60,
+    "id1": "selfdestruction",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts  create an explosion when they die."
   },
   {
-    "id1": 47,
-    "id2": 61,
+    "id1": "selfdestruction",
+    "id2": "walkinginfested",
     "interaction": "Infested create an explosion when they die."
   },
   {
-    "id1": 47,
-    "id2": 63,
+    "id1": "selfdestruction",
+    "id2": "boombots",
     "interaction": "Boom Bots create an explosion when they die."
   },
   {
-    "id1": 51,
-    "id2": 54,
+    "id1": "speedfreaks",
+    "id2": "transmutation",
     "interaction": "Transmuted units move faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 55,
+    "id1": "speedfreaks",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians move faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 56,
+    "id1": "speedfreaks",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys do not move faster with Speed Freaks. The Turking moves faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 59,
+    "id1": "speedfreaks",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators move faster with Speed Freaks. Resurrected units move faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 60,
+    "id1": "speedfreaks",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts move faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 61,
+    "id1": "speedfreaks",
+    "id2": "walkinginfested",
     "interaction": "Infested units move faster with Speed Freaks."
   },
   {
-    "id1": 51,
-    "id2": 63,
+    "id1": "speedfreaks",
+    "id2": "boombots",
     "interaction": "Boom Bots move faster with Speed Freaks."
   },
   {
-    "id1": 52,
-    "id2": 62,
+    "id1": "temporalfield",
+    "id2": "wemoveunseen",
     "interaction": "Temporal Fields are not cloaked."
   },
   {
-    "id1": 53,
-    "id2": 62,
+    "id1": "timewarp",
+    "id2": "wemoveunseen",
     "interaction": "Time Warps are not cloaked."
   },
   {
-    "id1": 54,
-    "id2": 55,
+    "id1": "transmutation",
+    "id2": "trickortreat",
     "interaction": "Units spawned from Civilians can Transmute."
   },
   {
-    "id1": 54,
-    "id2": 56,
+    "id1": "transmutation",
+    "id2": "turkeyshoot",
     "interaction": "Turkeys can transmute when they deal damage or kill a unit. The Turking does not transmute."
   },
   {
-    "id1": 54,
-    "id2": 59,
+    "id1": "transmutation",
+    "id2": "voidreanimators",
     "interaction": "Resurrected units can Transmute."
   },
   {
-    "id1": 54,
-    "id2": 60,
+    "id1": "transmutation",
+    "id2": "voidrifts",
     "interaction": "Units spawned from Void Rifts can transmute."
   },
   {
-    "id1": 54,
-    "id2": 61,
+    "id1": "transmutation",
+    "id2": "walkinginfested",
     "interaction": "Infested can transmute. Newly-transmuted units spawn Infested when they die."
   },
   {
-    "id1": 54,
-    "id2": 62,
+    "id1": "transmutation",
+    "id2": "wemoveunseen",
     "interaction": "Transmuted units are cloaked."
   },
   {
-    "id1": 55,
-    "id2": 59,
+    "id1": "trickortreat",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can resurrect units spawned from Civilians."
   },
   {
-    "id1": 55,
-    "id2": 60,
+    "id1": "trickortreat",
+    "id2": "voidrifts",
     "interaction": "Civilians do not spawn from Void Rifts."
   },
   {
-    "id1": 55,
-    "id2": 61,
+    "id1": "trickortreat",
+    "id2": "walkinginfested",
     "interaction": "Units spawned from Civilians spawn Infested when they die."
   },
   {
-    "id1": 55,
-    "id2": 62,
+    "id1": "trickortreat",
+    "id2": "wemoveunseen",
     "interaction": "Units spawned from Civilians are cloaked."
   },
   {
-    "id1": 56,
-    "id2": 59,
+    "id1": "turkeyshoot",
+    "id2": "voidreanimators",
     "interaction": "Void Reanimators can resurrect Turkeys. Void Reanimators do not resurrect the Turking."
   },
   {
-    "id1": 56,
-    "id2": 61,
+    "id1": "turkeyshoot",
+    "id2": "walkinginfested",
     "interaction": "Turkeys do not spawn Infested when they die. Angry Turkeys spawn Infested when they die. The Turking does not spawn Infested when it dies."
   },
   {
-    "id1": 56,
-    "id2": 62,
+    "id1": "turkeyshoot",
+    "id2": "wemoveunseen",
     "interaction": "Turkeys are not cloaked. The Turking is cloaked."
   },
   {
-    "id1": 57,
-    "id2": 62,
+    "id1": "twister",
+    "id2": "wemoveunseen",
     "interaction": "Twisters are not cloaked."
   },
   {
-    "id1": 59,
-    "id2": 60,
+    "id1": "voidreanimators",
+    "id2": "voidrifts",
     "interaction": "Void Reanimators can resurrect units spawned from Void Rifts.\r\nVoid Reanimators do not spawn from Void Rifts."
   },
   {
-    "id1": 59,
-    "id2": 61,
+    "id1": "voidreanimators",
+    "id2": "walkinginfested",
     "interaction": "Void Reanimators can resurrect Infested."
   },
   {
-    "id1": 59,
-    "id2": 62,
+    "id1": "voidreanimators",
+    "id2": "wemoveunseen",
     "interaction": "Void Reanimators are cloaked."
   },
   {
-    "id1": 59,
-    "id2": 63,
+    "id1": "voidreanimators",
+    "id2": "boombots",
     "interaction": "Void Reanimators do not resurrect Boom Bots."
   },
   {
-    "id1": 60,
-    "id2": 61,
+    "id1": "voidrifts",
+    "id2": "walkinginfested",
     "interaction": "Units spawned from Void Rifts spawn Infested when they die."
   },
   {
-    "id1": 60,
-    "id2": 62,
+    "id1": "voidrifts",
+    "id2": "wemoveunseen",
     "interaction": "Units spawned from Void Rifts are cloaked."
   },
   {
-    "id1": 60,
-    "id2": 63,
+    "id1": "voidrifts",
+    "id2": "boombots",
     "interaction": "Boom Bots do not spawn from Void Rifts."
   },
   {
-    "id1": 61,
-    "id2": 62,
+    "id1": "walkinginfested",
+    "id2": "wemoveunseen",
     "interaction": "Infested are cloaked."
   },
   {
-    "id1": 61,
-    "id2": 63,
+    "id1": "walkinginfested",
+    "id2": "boombots",
     "interaction": "Boom Bots spawn Infested when they die."
   },
   {
-    "id1": 62,
-    "id2": 63,
+    "id1": "wemoveunseen",
+    "id2": "boombots",
     "interaction": "Boom Bots are cloaked, but their tags are still visible.\r\nCodes cannot be input without detection."
   }
 ]

--- a/source-data/mutatorinteractions.json
+++ b/source-data/mutatorinteractions.json
@@ -21,7 +21,7 @@
   },
   {
     "id1": "afraidofthedark",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines appear on the minimap."
   },
   {
@@ -261,7 +261,7 @@
   },
   {
     "id1": "alienincubation",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines do not spawn Broodlings when they detonate."
   },
   {
@@ -381,7 +381,7 @@
   },
   {
     "id1": "avenger",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines do not give out Avenger stacks when they detonate."
   },
   {
@@ -556,7 +556,7 @@
   },
   {
     "id1": "blackdeath",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines cannot carry Plague."
   },
   {
@@ -706,7 +706,7 @@
   },
   {
     "id1": "concussiveattacks",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mines apply the Concussive Attacks debuff."
   },
   {
@@ -816,7 +816,7 @@
   },
   {
     "id1": "darkness",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines appear on the minimap."
   },
   {
@@ -1051,7 +1051,7 @@
   },
   {
     "id1": "fatalattraction",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines trigger Fatal Attraction when they detonate."
   },
   {
@@ -1161,7 +1161,7 @@
   },
   {
     "id1": "fear",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mines can apply the Fear effect."
   },
   {
@@ -1261,7 +1261,7 @@
   },
   {
     "id1": "fireworks",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mines do not launch Fireworks when they explode."
   },
   {
@@ -1361,7 +1361,7 @@
   },
   {
     "id1": "giftexchange",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines can capture gifts."
   },
   {
@@ -1496,7 +1496,7 @@
   },
   {
     "id1": "hardenedwill",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines do not cause Hardened Will to activate."
   },
   {
@@ -1696,7 +1696,7 @@
   },
   {
     "id1": "justdie",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines do not respawn when they explode."
   },
   {
@@ -1866,7 +1866,7 @@
   },
   {
     "id1": "laserdrill",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines provide vision for the Laser Drill."
   },
   {
@@ -2001,7 +2001,7 @@
   },
   {
     "id1": "longrange",
-    "id2": "magnificent",
+    "id2": "mag-nificent",
     "interaction": "Mag-mines do not get the Long Range buff."
   },
   {
@@ -2050,42 +2050,42 @@
     "interaction": "Units spawned from Void Rifts get the Long Range buff."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "poweroverwhelming",
     "interaction": "Mag-mines cannot cast abilities."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "scorchedearth",
     "interaction": "Mag-mines do not set the ground on fire when they explode."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "selfdestruction",
     "interaction": "Mag-mines do not create an explosion when explode."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "speedfreaks",
     "interaction": "Mag-mines do not move faster with Speed Freaks."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "transmutation",
     "interaction": "Mag-mines do not Transmute after killing a unit."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "voidreanimators",
     "interaction": "Void Reanimators do not resurrect Mag-mines."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "walkinginfested",
     "interaction": "Mag-mines do not spawn Infested when they detonate."
   },
   {
-    "id1": "magnificent",
+    "id1": "mag-nificent",
     "id2": "wemoveunseen",
     "interaction": "Mag-mines are cloaked."
   },

--- a/source-data/schemas/mutatorinteractions.schema.json
+++ b/source-data/schemas/mutatorinteractions.schema.json
@@ -13,11 +13,13 @@
             "properties": {
                 "id1": {
                     "type": "string",
-                    "description": "ID of the first mutator in the pair"
+                    "description": "ID of the first mutator in the pair, Normalized",
+                    "pattern": "^[a-z0-9]+$"
                 },
                 "id2": {
                     "type": "string",
-                    "description": "ID of the second mutator in the pair (id2 > id1)"
+                    "description": "ID of the second mutator in the pair, Normalized & id2 > id1",
+                    "pattern": "^[a-z0-9]+$"
                 },
                 "interaction": {
                     "type": "string",

--- a/source-data/schemas/mutatorinteractions.schema.json
+++ b/source-data/schemas/mutatorinteractions.schema.json
@@ -12,11 +12,11 @@
             "type": "object",
             "properties": {
                 "id1": {
-                    "$ref": "#/definitions/PositiveInteger",
+                    "type": "string",
                     "description": "ID of the first mutator in the pair"
                 },
                 "id2": {
-                    "$ref": "#/definitions/PositiveInteger",
+                    "type": "string",
                     "description": "ID of the second mutator in the pair (id2 > id1)"
                 },
                 "interaction": {
@@ -30,10 +30,6 @@
                 "interaction"
             ],
             "additionalProperties": false
-        },
-        "PositiveInteger": {
-            "type": "integer",
-            "minimum": 1
         }
     }
 }

--- a/source-data/schemas/mutatorinteractions.schema.json
+++ b/source-data/schemas/mutatorinteractions.schema.json
@@ -12,14 +12,12 @@
             "type": "object",
             "properties": {
                 "id1": {
-                    "type": "string",
-                    "description": "ID of the first mutator in the pair, Normalized",
-                    "pattern": "^[a-z0-9]+$"
+                    "$ref": "#/definitions/MutatorId",
+                    "description": "ID of the first mutator in the pair, lowercased & without spaces"
                 },
                 "id2": {
-                    "type": "string",
-                    "description": "ID of the second mutator in the pair, Normalized & id2 > id1",
-                    "pattern": "^[a-z0-9]+$"
+                    "$ref": "#/definitions/MutatorId",
+                    "description": "ID of the second mutator in the pair, lowercased & without spaces, id2 > id1"
                 },
                 "interaction": {
                     "type": "string",
@@ -32,6 +30,13 @@
                 "interaction"
             ],
             "additionalProperties": false
+        },
+        "MutatorId": {
+            "$ref": "#/definitions/LowercaseNoSpaces"
+        },
+        "LowercaseNoSpaces": {
+            "type": "string",
+            "pattern": "^[^ A-Z]+$"
         }
     }
 }

--- a/source-data/validate.ts
+++ b/source-data/validate.ts
@@ -30,7 +30,7 @@ for (const [file, type] of files) {
 const mutatorInteractions: MutatorInteractionList = await Bun.file('source-data/mutatorinteractions.json').json();
 for (const [i, entry] of mutatorInteractions.entries()) {
     if (entry.id1 >= entry.id2) {
-        console.error(`mutatorinteractions.json[${i}]: id1 (${entry.id1}) must be less than id2 (${entry.id2})`);
+        console.error(`mutatorinteractions.json[${i}]: id1 (${entry.id1}) must be strictly less than id2 (${entry.id2})`);
         process.exit(1);
     }
 }


### PR DESCRIPTION
Use mutatorIds as Mutator Names Lowercased and without spaces, exactly as PHP & JS

make sure text id1 < text id2
update HTML & JS in mutators.php to use human-ish IDs
use flag values "NONE" (for '-') and "ALL" (for 'show all interactions')
since they are uppercase, they can _never_ conflict with a mutator id
use new mutatorId directly as filename for images