### PR TITLE
Remove scripts in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,5 @@
 {
     "require-dev": {
         "squizlabs/php_codesniffer": "*"
-    },
-    "scripts": {
-        "ci": "phpcs --ignore=vendor,.dh-diag -n .",
-        "fix": "phpcbf --ignore=vendor,.dh-diag -n ."
     }
 }


### PR DESCRIPTION
Since the Makefile(s) define all the params for 'check' and 'fix', the
  'scripts' portion of composer.json is no longer needed.